### PR TITLE
fix: do not invalidate session if offline when identification fails.

### DIFF
--- a/addons/talo/apis/players_api.gd
+++ b/addons/talo/apis/players_api.gd
@@ -16,7 +16,8 @@ func identify(service: String, identifier: String) -> void:
 			Talo.current_alias = TaloPlayerAlias.new(res.body.alias)
 			identified.emit(Talo.current_player)
 		_:
-			Talo.player_auth.session_manager.clear_session()
+			if not await Talo.is_offline():
+				Talo.player_auth.session_manager.clear_session()
 
 ## Identify a player using a Steam ticket.
 func identify_steam(ticket: String, identity: String = "") -> void:


### PR DESCRIPTION
Fixes an issue where the session (token and identifier) was deleted if the server was unreachable during `Talo` initialization.
Player had to re-authenticate.

With this fix, players will be identified after relaunching the game, or if gamedevs explicitly call `Talo._check_session()` (which isn't part of the API).