### PR TITLE
refactor: change some SessionManager variable names for consistency

### DIFF
--- a/addons/talo/apis/players_api.gd
+++ b/addons/talo/apis/players_api.gd
@@ -28,7 +28,7 @@ func identify_steam(ticket: String, identity: String = "") -> void:
 
 ## Flush and sync the player's current data with Talo.
 func update() -> void:
-	var res = await client.make_request(HTTPClient.METHOD_PATCH, "/%s" % Talo.current_player.id, { props = Talo.current_player.get_serialized_props() })
+	var res = await client.make_request(HTTPClient.METHOD_PATCH, "/%s" % Talo.current_player.id, {props = Talo.current_player.get_serialized_props()})
 	match (res.status):
 		200:
 			Talo.current_alias.player = TaloPlayer.new(res.body.player)

--- a/addons/talo/apis/players_api.gd
+++ b/addons/talo/apis/players_api.gd
@@ -28,7 +28,7 @@ func identify_steam(ticket: String, identity: String = "") -> void:
 
 ## Flush and sync the player's current data with Talo.
 func update() -> void:
-	var res = await client.make_request(HTTPClient.METHOD_PATCH, "/%s" % Talo.current_player.id, {props = Talo.current_player.get_serialized_props()})
+	var res = await client.make_request(HTTPClient.METHOD_PATCH, "/%s" % Talo.current_player.id, { props = Talo.current_player.get_serialized_props() })
 	match (res.status):
 		200:
 			Talo.current_alias.player = TaloPlayer.new(res.body.player)

--- a/addons/talo/talo_client.gd
+++ b/addons/talo/talo_client.gd
@@ -22,7 +22,7 @@ func _simulate_offline_request():
 		PackedByteArray()
 	]
 
-func make_request(method: HTTPClient.Method, url: String, body: Dictionary = {}, headers: Array[String] = [], continuity: bool = false) -> Dictionary:	
+func make_request(method: HTTPClient.Method, url: String, body: Dictionary = {}, headers: Array[String] = [], continuity: bool = false) -> Dictionary:
 	var continuity_timestamp = TimeUtils.get_timestamp_msec()
 
 	var full_url = url if continuity else _build_full_url(url)
@@ -89,7 +89,7 @@ func _build_headers(extra_headers: Array[String] = []) -> Array[String]:
 			"X-Talo-Alias: %s" % Talo.current_alias.id
 		])
 
-	var session_token = Talo.player_auth.session_manager.load_session()
+	var session_token = Talo.player_auth.session_manager.get_token()
 	if session_token:
 		headers.append("X-Talo-Session: %s" % session_token)
 

--- a/addons/talo/talo_manager.gd
+++ b/addons/talo/talo_manager.gd
@@ -115,6 +115,6 @@ func _do_flush() -> void:
 		events.flush()
 
 func _check_session() -> void:
-	var session_token = player_auth.session_manager.load_session()
+	var session_token = player_auth.session_manager.get_token()
 	if not session_token.is_empty():
 		players.identify("talo", player_auth.session_manager.get_identifier())

--- a/addons/talo/utils/session_manager.gd
+++ b/addons/talo/utils/session_manager.gd
@@ -1,32 +1,32 @@
 class_name TaloSessionManager extends Node
 
-var _config_file_path = "user://talo_session.cfg"
+var _session_config_path = "user://talo_session.cfg"
 var _verification_alias_id = ""
 
-func _load_config() -> ConfigFile:
+func _load_config(path: String) -> ConfigFile:
 	var config = ConfigFile.new()
-	config.load(_config_file_path)
+	config.load(path)
 	return config
 
 func _save_session(session_token: String) -> void:
 	var config = ConfigFile.new()
 	config.set_value("session", "token", session_token)
 	config.set_value("session", "identifier", Talo.current_alias.identifier)
-	config.save(_config_file_path)
+	config.save(_session_config_path)
 
 func clear_session() -> void:
-	var config = _load_config()
+	var config = _load_config(_session_config_path)
 
 	if config.has_section("session"):
 		config.erase_section("session")
-		config.save(_config_file_path)
+		config.save(_session_config_path)
 
-func load_session() -> String:
-	var config = _load_config()
+func get_token() -> String:
+	var config = _load_config(_session_config_path)
 	return config.get_value("session", "token", "")
 
 func get_identifier() -> String:
-	var config = _load_config()
+	var config = _load_config(_session_config_path)
 	return config.get_value("session", "identifier", "")
 
 func save_verification_alias_id(alias_id: int) -> void:


### PR DESCRIPTION
Got weirded out by `load_session()` only returning the token 😆