### PR TITLE
Fixed a typo in func generate_identifer()

### DIFF
--- a/addons/talo/apis/players_api.gd
+++ b/addons/talo/apis/players_api.gd
@@ -47,7 +47,7 @@ func merge(player_id1: String, player_id2: String) -> TaloPlayer:
 			return null
 
 ## Generate a mostly-unique identifier.
-func generate_identifer() -> String:
+func generate_identifier() -> String:
 	var time_hash: String = str(TimeUtils.get_timestamp_msec()).sha256_text()
 	var size = 12
 	var split_start: int = RandomNumberGenerator.new().randi_range(0, time_hash.length() - size)


### PR DESCRIPTION
Function `generate_identifer()` renamed to `generate_identifier()`