### PR TITLE
Fix: Corrected URL data appending in get_entries method

### DIFF
--- a/addons/talo/apis/leaderboards_api.gd
+++ b/addons/talo/apis/leaderboards_api.gd
@@ -28,7 +28,7 @@ func get_entries(internal_name: String, page: int, alias_id = -1, include_archiv
 
 	if alias_id != -1:
 		url += "&aliasId=%s"
-		url_data += alias_id
+		url_data.append(alias_id)
 
 	if include_archived:
 		url += "&withDeleted=1"


### PR DESCRIPTION
Appending an item to the array using the += operator causes a crash. This commit uses array.append to added the `alias_id` to the array