### PR TITLE
Disallow SavesManager to emit SavesAPI's signals.

### DIFF
--- a/addons/talo/apis/saves_api.gd
+++ b/addons/talo/apis/saves_api.gd
@@ -68,6 +68,8 @@ func get_saves() -> Array[TaloGameSave]:
 ## Set the chosen save and optionally (default true) load it.
 func choose_save(save: TaloGameSave, load_save = true) -> void:
 	_saves_manager.set_chosen_save(save, load_save)
+	if load_save:
+		save_chosen.emit(save)
 
 ## Unload the current save.
 func unload_current_save() -> void:
@@ -108,7 +110,9 @@ func register(loadable: TaloLoadable) -> void:
 
 ## Mark an object as loaded.
 func set_object_loaded(id: String) -> void:
-	_saves_manager.set_object_loaded(id)
+	_saves_manager.push_loaded_object(id)
+	if _saves_manager.is_loading_completed():
+		save_loading_completed.emit()
 
 ## Update the currently loaded save using the current state of the game and with the given name.
 func update_current_save(new_name: String = "") -> TaloGameSave:

--- a/addons/talo/utils/saves_manager.gd
+++ b/addons/talo/utils/saves_manager.gd
@@ -53,7 +53,7 @@ func sync_offline_saves(offline_saves: Array[TaloGameSave]) -> Array[TaloGameSav
 			var save = await Talo.saves.create_save(offline_save.display_name, offline_save.content)
 			delete_offline_save(offline_save)
 			new_saves.push_back(save)
-	
+
 	return new_saves
 
 func get_synced_saves(online_saves: Array[TaloGameSave]) -> Array[TaloGameSave]:
@@ -102,15 +102,15 @@ func set_chosen_save(save: TaloGameSave, load_save: bool) -> void:
 		return
 
 	_loaded_loadables.clear()
-	Talo.saves.save_chosen.emit(save)
 
 func register(loadable: TaloLoadable) -> void:
 	_registered_saved_objects.push_back(TaloSavedObject.new(loadable))
 
-func set_object_loaded(id: String) -> void:
+func push_loaded_object(id: String) -> void:
 	_loaded_loadables.push_back(id)
-	if _loaded_loadables.size() == _registered_saved_objects.size():
-		Talo.saves.save_loading_completed.emit()
+
+func is_loading_completed() -> bool:
+	return _loaded_loadables.size() == _registered_saved_objects.size()
 
 func get_save_content() -> Dictionary:
 	return {


### PR DESCRIPTION
A part of #70 .

A defined signal without using by itself will be recognized as a standalone expression.