### PR TITLE
Add `TaloMultiplayerPeer` and multiplayer sample.

### DIFF
--- a/addons/talo/samples/multiplayer/multiplayer.tscn
+++ b/addons/talo/samples/multiplayer/multiplayer.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://d2y2fyjhcu688"]
+
+[ext_resource type="Script" path="res://addons/talo/samples/multiplayer/scripts/multiplayer.gd" id="1_uay0c"]
+
+[node name="Multiplayer" type="Node2D"]
+script = ExtResource("1_uay0c")
+
+[node name="Identify" type="VBoxContainer" parent="."]
+unique_name_in_owner = true
+offset_left = 16.0
+offset_top = 16.0
+offset_right = 400.0
+offset_bottom = 74.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Identify"]
+layout_mode = 2
+
+[node name="IdentifierLineEdit" type="LineEdit" parent="Identify/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "identifier..."
+
+[node name="IdentifyButton" type="Button" parent="Identify/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Identify"
+
+[node name="MessageLabel" type="Label" parent="Identify"]
+unique_name_in_owner = true
+layout_mode = 2

--- a/addons/talo/samples/multiplayer/player.tscn
+++ b/addons/talo/samples/multiplayer/player.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=4 format=3 uid="uid://du82kmf6hub41"]
+
+[ext_resource type="Texture2D" uid="uid://b3naludt1ank2" path="res://icon.png" id="1_cm242"]
+[ext_resource type="Script" path="res://addons/talo/samples/multiplayer/scripts/player.gd" id="2_myrjg"]
+
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_sjscl"]
+properties/0/path = NodePath(".:position")
+properties/0/spawn = true
+properties/0/replication_mode = 2
+
+[node name="Player" type="Node2D"]
+script = ExtResource("2_myrjg")
+
+[node name="NameLabel" type="Label" parent="."]
+unique_name_in_owner = true
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -121.0
+offset_top = -81.0
+offset_right = 121.0
+offset_bottom = -58.0
+grow_horizontal = 2
+text = "Identifier"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="RpcTestButton" type="Button" parent="."]
+unique_name_in_owner = true
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -133.0
+offset_top = 57.0
+offset_right = 133.0
+offset_bottom = 88.0
+grow_horizontal = 2
+grow_vertical = 0
+focus_mode = 0
+text = "RpcTestButton"
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.1, 0.1)
+texture = ExtResource("1_cm242")
+
+[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="."]
+replication_interval = 0.03
+delta_interval = 0.03
+replication_config = SubResource("SceneReplicationConfig_sjscl")

--- a/addons/talo/samples/multiplayer/scripts/multiplayer.gd
+++ b/addons/talo/samples/multiplayer/scripts/multiplayer.gd
@@ -1,0 +1,111 @@
+extends Node2D
+
+
+@export var services := "username"
+@export var multiplayer_channel_name := "test_multiplayer_channel"
+
+var peer := TaloMultiplayerPeer.new()
+
+func _ready() -> void:
+	assert(not multiplayer_channel_name.is_empty())
+	%IdentifyButton.pressed.connect(_on_identify_btn_pressed)
+
+func _spawn_player(peer_id: int) -> void:
+	var player := preload("../player.tscn").instantiate()
+	player.name = str(peer_id)
+	player.setup(peer_id)
+	add_child(player)
+	if player.is_multiplayer_authority():
+		var vp_center := get_tree().root.size * 0.5
+		var spawn_range := vp_center * 0.4
+		var spawn_position := vp_center + Vector2(
+			randf_range(-spawn_range.x, spawn_range.x),
+			randf_range(-spawn_range.y, spawn_range.y)
+		)
+		player.position = spawn_position
+
+func _on_identify_btn_pressed() -> void:
+	var msg_label := %MessageLabel as Label
+	var btn := %IdentifyButton as Button
+
+	btn.disabled = true
+	# Identify
+	if Talo.identity_check(false) != OK:
+		var identifier := (%IdentifierLineEdit.text as String).strip_edges()
+		if identifier.is_empty():
+			msg_label.text = "Identify failed: identifier is empty."
+			btn.disabled = false
+			return
+
+		await Talo.players.identify(services, identifier)
+
+	if Talo.identity_check(false) != OK:
+		msg_label.text = "Identify failed: please check output for more details if logging is enabled."
+		btn.disabled = false
+		return
+
+
+	# Channels
+	var channel_id := -1
+	# Find exists channel.
+	var page := 0
+	while true:
+		var res := await Talo.channels.get_channels(page)
+		if not is_instance_valid(res):
+			msg_label.text = "Join channel failed: please check output for more details if logging is enabled."
+			btn.disabled = false
+			return
+
+		for channel: TaloChannel in res.channels:
+			if channel.name == multiplayer_channel_name:
+				channel_id = channel.id
+				break
+
+		if res.is_last_page:
+			# Last page.
+			break
+
+		page += 1
+
+	# Create new channel if not exists.
+	if channel_id < 0:
+		var channel := await Talo.channels.create(multiplayer_channel_name, true)
+		if not is_instance_valid(channel):
+			msg_label.text = "Join channel failed: please check output for more details if logging is enabled."
+			btn.disabled = false
+			return
+
+		channel_id = channel.id
+
+	# Join to the channel if need.
+	var subscribed_channels := await Talo.channels.get_subscribed_channels()
+	if subscribed_channels.all(func(channel: TaloChannel) -> bool: return channel.id != channel_id):
+		var joined_channel := await Talo.channels.join(channel_id)
+		if not is_instance_valid(joined_channel):
+			msg_label.text = "Join channel failed: please check output for more details if logging is enabled."
+			btn.disabled = false
+			return
+
+
+	# Join successful, setup TaloMultiplayerPeer
+	get_tree().get_multiplayer().multiplayer_peer = peer
+	if peer.listen_channel(channel_id) != OK:
+		btn.disabled = false
+		return
+
+	peer.peer_connected.connect(_on_peer_connected)
+	peer.peer_disconnected.connect(_on_peer_disconnected)
+
+	%Identify.hide()
+	_spawn_player(peer.get_unique_id())
+
+func _on_peer_connected(id: int) -> void:
+	_spawn_player(id)
+
+func _on_peer_disconnected(id: int) -> void:
+	for node in get_children():
+		if node.name != str(id):
+			continue
+		remove_child(node)
+		node.queue_free()
+		return

--- a/addons/talo/samples/multiplayer/scripts/player.gd
+++ b/addons/talo/samples/multiplayer/scripts/player.gd
@@ -1,0 +1,38 @@
+extends Node2D
+
+
+const SPEED = 100.0
+
+
+var _rpc_test_btn :Button:
+	get:
+		return %RpcTestButton
+
+
+func _ready() -> void:
+	_rpc_test_btn.disabled = not is_multiplayer_authority()
+	_rpc_test_btn.pressed.connect(_on_rpc_test_btn_pressed)
+
+func _process(delta: float) -> void:
+	if not is_multiplayer_authority():
+		return
+
+	var dir := Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
+	if dir.is_zero_approx():
+		return
+
+	translate(dir * SPEED * delta)
+
+func setup(peer_id: int) -> void:
+	set_multiplayer_authority(peer_id)
+	%NameLabel.text = str(peer_id)
+	if is_inside_tree():
+		_rpc_test_btn.disabled = not is_multiplayer_authority()
+
+@rpc("authority", "call_local", "reliable", 1)
+func _rpc_test(text: String) -> void:
+	_rpc_test_btn.text = str(text)
+
+
+func _on_rpc_test_btn_pressed() -> void:
+	_rpc_test.rpc("RpcTestButton: %s" % randi())

--- a/addons/talo/talo_multiplayer_peer.gd
+++ b/addons/talo/talo_multiplayer_peer.gd
@@ -1,0 +1,272 @@
+## Implemented through Talo Channels API.
+## All peers are clients, there have not server peer in this implementation.
+## Use "listen_channel()" to listen to a talo channel and start behave as a multiplayer peer.
+## Note: unique id is equal to TaloAlias.id.
+## Limitations:
+## - Only support reliable mode.
+## - Different transfer channels( not talo channels) has not essential difference.
+## - "disconnect_peer()" is not implemented, there have not server peer and not one have ability to kick a talo player from a talo channel.
+## - Can't refuse new connections, the reason is similar to previous one.
+
+class_name TaloMultiplayerPeer
+extends MultiplayerPeerExtension
+
+const MAGIC_PREFIX := "^TLMP^|"
+static var MAX_PACKET_SIZE: int = 1024
+
+const STOP_SENDING_INTERVAL_MSEC := 500
+
+var _connected_peers := PackedInt32Array()
+var _talo_channel_id: int = -1
+var _incoming_packets: Array[Array] # Each element is an incoming packet, see [enum _PacketField] for more details.
+var _target_peer := -1
+var _transfer_channel := 0
+
+enum _Event {
+	PACKET,
+	CONNECT,
+	DISCONNECT,
+}
+
+# Pack Definition.
+enum _PacketField {
+	EVENT,
+	PEER, # Sender peer of incoming packet. Target peer of sending packet.
+	CHANNEL,
+	DATA,
+
+	MAX, # Not a file of packet.
+}
+
+
+var _pending_message_queue: PackedStringArray = []
+var _sending_enable_tick_msec := -1
+
+
+## Listen to a joined talo channel and start behave as a multiplayer peer.
+func listen_channel(talo_channel_id: int) -> Error:
+	assert(talo_channel_id >= 0)
+
+	if _talo_channel_id >= 0:
+		push_error("Already listen channel: %s. Please close it first." % _talo_channel_id)
+		return ERR_ALREADY_IN_USE
+
+	if Talo.identity_check() != OK:
+		return ERR_UNAUTHORIZED
+
+	_talo_channel_id = talo_channel_id
+	if _send_packet_message(_Event.CONNECT, 0, 0) != OK:
+		push_error("Listen channel failed.")
+		_talo_channel_id = -1
+		return ERR_CONNECTION_ERROR
+
+	Talo.channels.message_received.connect(_on_channels_message_received)
+	Talo.channels.player_left.connect(_on_channels_player_left)
+	Talo.channels.channel_deleted.connect(_on_channels_channel_deleted)
+	Talo.socket.error_received.connect(_on_socket_error_received)
+
+	if not _connected_peers.has(Talo.current_alias.id):
+		_connected_peers.push_back(Talo.current_alias.id)
+
+
+	return OK
+
+func _make_incoming_packet(event: _Event, sender_peer: int, channel: int, data := PackedByteArray()) -> Array:
+	var ret := []
+	ret.resize(_PacketField.MAX)
+	ret[_PacketField.EVENT] = event
+	ret[_PacketField.PEER] = sender_peer
+	ret[_PacketField.CHANNEL] = channel
+	ret[_PacketField.DATA] = data
+	return ret
+
+func _on_channels_message_received(talo_channel: TaloChannel, player_alias: TaloPlayerAlias, message: String) -> void:
+	if talo_channel.id != _talo_channel_id:
+		# Message is not from listening talo channel.
+		return
+
+	if player_alias.id == Talo.current_alias.id:
+		# Skip message from self.
+		return
+
+	if not message.begins_with(MAGIC_PREFIX):
+		# Not packet message.
+		return
+
+	if _get_connection_status() != MultiplayerPeer.CONNECTION_CONNECTED:
+		# Local is not connected.
+		return
+
+	for msg in message.split(MAGIC_PREFIX, false):
+		# Deserialize
+		var packet := msg.trim_prefix(MAGIC_PREFIX).split("|")
+		assert(packet.size() in [_PacketField.MAX, _PacketField.MAX - 1])
+		var event := packet[_PacketField.EVENT].to_int() as _Event
+		var target_peer := packet[_PacketField.PEER].to_int()
+		var channel := packet[_PacketField.CHANNEL].to_int()
+		var data: PackedByteArray
+		if packet.size() == _PacketField.MAX:
+			data = Marshalls.base64_to_raw(packet[_PacketField.DATA])
+			assert(not data.is_empty())
+
+		var sender_peer := player_alias.id
+		match event:
+			_Event.PACKET:
+				if target_peer != 0 and target_peer != Talo.current_alias.id:
+					# Not broadcast and not sent to local peer.
+					return
+
+				if not _connected_peers.has(sender_peer):
+					# Add to connected list if it is not exists.
+					_connected_peers.push_back(sender_peer)
+					peer_connected.emit(sender_peer)
+
+				assert(not data.is_empty())
+				_incoming_packets.push_back(_make_incoming_packet(event, sender_peer, channel, data))
+			_Event.CONNECT:
+				if _connected_peers.has(sender_peer):
+					return
+				_connected_peers.push_back(sender_peer)
+				_send_packet_message(_Event.CONNECT, sender_peer, 0) # Send connected peers to the new connected peer.
+				peer_connected.emit(sender_peer)
+			_Event.DISCONNECT:
+				if not _connected_peers.has(sender_peer):
+					return
+				_connected_peers.remove_at(_connected_peers.find(sender_peer))
+				peer_disconnected.emit(sender_peer)
+
+func _on_channels_player_left(talo_channel: TaloChannel, player_alias: TaloPlayerAlias) -> void:
+	if talo_channel.id == _talo_channel_id and player_alias.id in _connected_peers:
+		_connected_peers.remove_at(_connected_peers.find(player_alias.id))
+		peer_disconnected.emit(player_alias.id)
+		if player_alias.id == Talo.current_alias.id:
+			_close()
+
+func _on_channels_channel_deleted(talo_channel: TaloChannel) -> void:
+	while not _connected_peers.is_empty():
+		var peer := _connected_peers[-1]
+		_connected_peers.remove_at(-1)
+		peer_disconnected.emit(peer)
+	_close()
+
+func _send_packet_message(event: _Event, target_peer: int, channel: int, data := PackedByteArray()) -> Error:
+	if Talo.identity_check() == OK and _talo_channel_id >= 0:
+		# Serialize.
+		var msg := "%s%s|%s|%s" % [MAGIC_PREFIX, event, target_peer, channel]
+		if not data.is_empty():
+			msg += "|%s" % Marshalls.raw_to_base64(data)
+		_pending_message_queue.push_back(msg)
+		return OK
+	else:
+		return ERR_INVALID_PARAMETER
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_PREDELETE:
+		_close()
+
+func _close() -> void:
+	if _talo_channel_id < 0:
+		return
+
+	Talo.channels.message_received.disconnect(_on_channels_message_received)
+	Talo.channels.player_left.disconnect(_on_channels_player_left)
+	Talo.channels.channel_deleted.disconnect(_on_channels_channel_deleted)
+	Talo.socket.error_received.disconnect(_on_socket_error_received)
+
+	if is_instance_valid(Talo.current_player) and _talo_channel_id >= 0:
+		_send_packet_message(_Event.PACKET, 0, 0)
+	_connected_peers.clear()
+	_talo_channel_id = -1
+
+func _disconnect_peer(_peer: int, _force: bool) -> void:
+	## Has not ability to disconnect peer.
+	pass
+
+func _get_available_packet_count() -> int:
+	return _incoming_packets.size()
+
+func _get_connection_status() -> MultiplayerPeer.ConnectionStatus:
+	if Talo.identity_check(false) == OK:
+		if _talo_channel_id >= 0:
+			if _connected_peers.has(Talo.current_alias.id):
+				return MultiplayerPeer.CONNECTION_CONNECTED
+			else:
+				return MultiplayerPeer.CONNECTION_CONNECTING
+	return MultiplayerPeer.CONNECTION_CONNECTED
+
+func _get_max_packet_size() -> int:
+	return MAX_PACKET_SIZE
+
+func _get_unique_id() -> int:
+	if Talo.identity_check() == OK:
+		return Talo.current_alias.id
+	return -1
+
+func _is_server() -> bool:
+	return false
+
+func _is_server_relay_supported() -> bool:
+	return false
+
+func _poll() -> void:
+	if _pending_message_queue.is_empty() or Time.get_ticks_msec() < _sending_enable_tick_msec:
+		return
+	if Talo.identity_check() == OK and _talo_channel_id >= 0:
+		Talo.channels.send_message(_talo_channel_id, "".join(_pending_message_queue))
+		_pending_message_queue.clear()
+
+func _put_packet_script(p_buffer: PackedByteArray) -> Error:
+	return _send_packet_message(_Event.PACKET, _target_peer, _transfer_channel, p_buffer)
+
+func _get_packet_script() -> PackedByteArray:
+	var packet := _incoming_packets.pop_front()
+	assert(not packet[_PacketField.DATA].is_empty())
+	return packet[_PacketField.DATA]
+
+func _set_refuse_new_connections(_enable: bool) -> void:
+	assert(false, "Unsupported feature.")
+
+func _is_refusing_new_connections() -> bool:
+	return false
+
+func _set_target_peer(p_peer: int) -> void:
+	_target_peer = p_peer
+
+func _set_transfer_channel(p_channel: int) -> void:
+	_transfer_channel = p_channel
+
+func _get_transfer_channel() -> int:
+	return _transfer_channel
+
+func _set_transfer_mode(p_mode: MultiplayerPeer.TransferMode) -> void:
+	assert(p_mode == MultiplayerPeer.TRANSFER_MODE_RELIABLE, "Only support reliable mode.")
+
+func _get_transfer_mode() -> MultiplayerPeer.TransferMode:
+	# Only support reliable mode.
+	return MultiplayerPeer.TRANSFER_MODE_RELIABLE
+
+func _get_packet_mode() -> MultiplayerPeer.TransferMode:
+	# Only support reliable mode.
+	return MultiplayerPeer.TRANSFER_MODE_RELIABLE
+
+func _get_packet_channel() -> int:
+	if _incoming_packets.is_empty():
+		return 0
+	else:
+		return _incoming_packets[0][_PacketField.CHANNEL]
+
+func _get_packet_peer() -> int:
+	if _incoming_packets.is_empty():
+		if Talo.identity_check() == OK:
+			return Talo.current_alias.id
+		else:
+			return -1
+	else:
+		return _incoming_packets[0][_PacketField.PEER]
+
+
+# ---
+func _on_socket_error_received(err: TaloSocketError) -> void:
+	if err.code == TaloSocketError.ErrorCode.RATE_LIMIT_EXCEEDED:
+		push_error("Rate limit exceeded. This peer will stop sending messages for a while. Please try to increase the sync intervals.")
+		_sending_enable_tick_msec = Time.get_ticks_msec() + STOP_SENDING_INTERVAL_MSEC


### PR DESCRIPTION
Implemented through Talo Channels.

Need #72 .

Need test.

--------------
Run two instances of `sample/multiplayer/multiplayer.tscn` and connect them. Then continuously moving one of them, the synchronization will be broken after few seconds and push error:
```
E 0:00:16:0622   talo_socket.gd:75 @ send(): Condition "ready_state != STATE_OPEN" is true. Returning: FAILED
  <C++ 源文件>      modules/websocket/wsl_peer.cpp:702 @ _send()
  <栈追踪>          talo_socket.gd:75 @ send()
                 channels_api.gd:153 @ send_message()
                 talo_multiplayer_peer.gd:145 @ _send_packet_message()
                 talo_multiplayer_peer.gd:202 @ _put_packet_script()

```


 @tudddorrr could you test this pr to find the reason about this error?