### PR TITLE
Add Export plugin

### DIFF
--- a/addons/talo/talo_autoload.gd
+++ b/addons/talo/talo_autoload.gd
@@ -1,8 +1,12 @@
 @tool
 extends EditorPlugin
 
+var export_plugin := TaloExportPlugin.new()
+
 func _enter_tree():
 	add_autoload_singleton("Talo", "res://addons/talo/talo_manager.gd")
+	add_export_plugin(export_plugin)
 
 func _exit_tree():
 	remove_autoload_singleton("Talo")
+	remove_export_plugin(export_plugin)

--- a/addons/talo/talo_export.gd
+++ b/addons/talo/talo_export.gd
@@ -1,0 +1,9 @@
+@tool
+class_name TaloExportPlugin extends EditorExportPlugin
+
+func _get_name() -> String:
+	return "talo"
+
+func _export_begin(features: PackedStringArray, is_debug: bool, path: String, flags: int) -> void:
+	var cfg_bytes : PackedByteArray = FileAccess.get_file_as_bytes("res://addons/talo/settings.cfg")
+	add_file("res://addons/talo/settings.cfg", cfg_bytes, false)

--- a/addons/talo/talo_export.gd.uid
+++ b/addons/talo/talo_export.gd.uid
@@ -1,0 +1,1 @@
+uid://cf0dp270fme3i


### PR DESCRIPTION
Adds an export plugin that gets loaded with talo which adds the cfg file to the exported project so that devs stop coming in and asking about why their exported project (usually android) isn't working.