### PR TITLE
Identify() and the identified signal now return a player alias

### DIFF
--- a/addons/talo/apis/players_api.gd
+++ b/addons/talo/apis/players_api.gd
@@ -6,7 +6,7 @@ class_name PlayersAPI extends TaloAPI
 ## @tutorial: https://docs.trytalo.com/docs/godot/identifying
 
 ## Emitted when a player has been identified.
-signal identified(player: TaloPlayer)
+signal identified(player_alias: TaloPlayerAlias)
 
 ## Emitted when identification starts.
 signal identification_started()
@@ -29,7 +29,7 @@ func _ready() -> void:
 func _handle_update_timer_timeout() -> void:
 	await Talo.players.update()
 
-func _handle_identify_success(alias: TaloPlayerAlias, socket_token: String = "") -> TaloPlayer:
+func _handle_identify_success(alias: TaloPlayerAlias, socket_token: String = "") -> TaloPlayerAlias:
 	if not await Talo.is_offline() and Talo.socket.is_identified():
 		Talo.socket.reset_connection()
 
@@ -38,11 +38,11 @@ func _handle_identify_success(alias: TaloPlayerAlias, socket_token: String = "")
 	if not socket_token.is_empty():
 		Talo.socket.set_socket_token(socket_token)
 
-	identified.emit(Talo.current_player)
-	return Talo.current_player
+	identified.emit(Talo.current_alias)
+	return Talo.current_alias
 
 ## Identify a player using a service (e.g. "username") and identifier (e.g. "bob").
-func identify(service: String, identifier: String) -> TaloPlayer:
+func identify(service: String, identifier: String) -> TaloPlayerAlias:
 	identification_started.emit()
 
 	if await Talo.is_offline():
@@ -60,14 +60,14 @@ func identify(service: String, identifier: String) -> TaloPlayer:
 			return null
 
 ## Identify a player using a Steam ticket.
-func identify_steam(ticket: String, identity: String = "") -> TaloPlayer:
+func identify_steam(ticket: String, identity: String = "") -> TaloPlayerAlias:
 	if identity.is_empty():
 		return await identify("steam", ticket)
 	else:
 		return await identify("steam", "%s:%s" % [identity, ticket])
 
 ## Identify a player using a Google Play Games auth code.
-func identify_google_play_games(auth_code: String) -> TaloPlayer:
+func identify_google_play_games(auth_code: String) -> TaloPlayerAlias:
 	return await identify("google_play_games", auth_code)
 
 ## Identify a player using an Apple Game Center identity verification signature. Signature and salt must be base64 encoded.
@@ -78,7 +78,7 @@ func identify_game_center(
 	timestamp: int,
 	player_id: String,
 	bundle_id: String
-) -> TaloPlayer:
+) -> TaloPlayerAlias:
 	var identifier := JSON.stringify({
 		"publicKeyUrl": public_key_url,
 		"signature": signature,
@@ -148,7 +148,7 @@ func generate_identifier() -> String:
 	return TaloCryptoManager.get_hashed_time(12)
 
 ## Attempt to identify a player when they're offline.
-func identify_offline(service: String, identifier: String) -> TaloPlayer:
+func identify_offline(service: String, identifier: String) -> TaloPlayerAlias:
 	var offline_alias := TaloPlayerAlias.get_offline_alias()
 	if offline_alias != null and offline_alias.matches_identify_request(service, identifier):
 		return await _handle_identify_success(offline_alias)

--- a/addons/talo/samples/authentication/scripts/authentication.gd
+++ b/addons/talo/samples/authentication/scripts/authentication.gd
@@ -55,4 +55,4 @@ func _configure_signals():
 	delete_account.delete_account_success.connect(func (): _make_state_visible(login))
 	delete_account.go_to_game.connect(func (): _make_state_visible(in_game))
 
-	Talo.players.identified.connect(func (player): _make_state_visible(in_game))
+	Talo.players.identified.connect(func (_player_alias: TaloPlayerAlias): _make_state_visible(in_game))

--- a/addons/talo/samples/authentication/scripts/in_game.gd
+++ b/addons/talo/samples/authentication/scripts/in_game.gd
@@ -12,16 +12,16 @@ func _ready() -> void:
 	Talo.players.identified.connect(_on_player_identified)
 
 	# identified signal emitted before the connection were made
-	if Talo.current_player:
-		_on_player_identified(Talo.current_player)
+	if Talo.current_alias:
+		_on_player_identified(Talo.current_alias)
 
 	# listen for the player changing their identifier
 	%ChangeIdentifier.identifier_change_success.connect(
-		func (): _on_player_identified(Talo.current_player)
+		func (): _on_player_identified(Talo.current_alias)
 	)
 
-func _on_player_identified(player: TaloPlayer) -> void:
-	username.text = "What would you like to do,\n%s?" % Talo.current_alias.identifier
+func _on_player_identified(player_alias: TaloPlayerAlias) -> void:
+	username.text = "What would you like to do,\n%s?" % player_alias.identifier
 
 func _on_change_password_pressed() -> void:
 	go_to_change_password.emit()

--- a/addons/talo/samples/chat/scripts/chat.gd
+++ b/addons/talo/samples/chat/scripts/chat.gd
@@ -20,7 +20,7 @@ func _on_presence_changed(presence: TaloPlayerPresence, online_changed: bool, cu
 	if online_changed:
 		_add_chat_message("[SYSTEM] %s is now %s" % [presence.player_alias.identifier, "online" if presence.online else "offline"])
 
-func _on_identified(player: TaloPlayer) -> void:
+func _on_identified(_player_alias: TaloPlayerAlias) -> void:
 	_subscriptions = await Talo.channels.get_subscribed_channels()
 
 	var options := Talo.channels.GetChannelsOptions.new()

--- a/addons/talo/samples/multiscene_saves/scripts/loadable_player.gd
+++ b/addons/talo/samples/multiscene_saves/scripts/loadable_player.gd
@@ -35,11 +35,11 @@ func _ready():
 	# register the loadable
 	super()
 
-func _on_identified(_player: TaloPlayer):
+func _on_identified(player_alias: TaloPlayerAlias):
 	var saves := await Talo.saves.get_saves()
 	if saves.is_empty():
 		# the save is automatically chosen after it is created
-		await Talo.saves.create_save("save (%s)" % Talo.current_alias.identifier)
+		await Talo.saves.create_save("save (%s)" % player_alias.identifier)
 	else:
 		await Talo.saves.choose_save(Talo.saves.all.front())
 

--- a/addons/talo/samples/persistent_buttons/persistent_buttons_manager.gd
+++ b/addons/talo/samples/persistent_buttons/persistent_buttons_manager.gd
@@ -6,7 +6,7 @@ func _ready() -> void:
 	Talo.players.identified.connect(_on_identified)
 	Talo.players.identify("username", username)
 
-func _on_identified(_player: TaloPlayer) -> void:
+func _on_identified(_player_alias: TaloPlayerAlias) -> void:
 	var saves := await Talo.saves.get_saves()
 	if saves.is_empty():
 		await Talo.saves.create_save("save")

--- a/addons/talo/samples/playground/scripts/identified_label.gd
+++ b/addons/talo/samples/playground/scripts/identified_label.gd
@@ -4,8 +4,8 @@ func _ready() -> void:
 	Talo.players.identified.connect(_on_identified)
 	Talo.players.identity_cleared.connect(_on_identity_cleared)
 
-func _on_identified(_player: TaloPlayer) -> void:
-	text = "Player identified (%s)" % Talo.current_alias.display_name
+func _on_identified(player_alias: TaloPlayerAlias) -> void:
+	text = "Player identified (%s)" % player_alias.display_name
 
 func _on_identity_cleared() -> void:
 	text = "Player identity cleared"

--- a/addons/talo/samples/playground/scripts/identified_state.gd
+++ b/addons/talo/samples/playground/scripts/identified_state.gd
@@ -6,7 +6,7 @@ func _ready() -> void:
 	Talo.players.identified.connect(_on_identified)
 	Talo.players.identity_cleared.connect(_on_identity_cleared)
 
-func _on_identified(_player: TaloPlayer) -> void:
+func _on_identified(_player_alias: TaloPlayerAlias) -> void:
 	color = Color(120.0 / 255.0, 230.0 / 255.0, 160.0 / 255.0)
 
 func _on_identity_cleared() -> void:

--- a/addons/talo/utils/session_manager.gd
+++ b/addons/talo/utils/session_manager.gd
@@ -61,7 +61,7 @@ func get_verification_alias_id() -> int:
 func handle_session_created(alias: Dictionary, session_token: String, refresh_token: String, socket_token: String) -> void:
 	Talo.current_alias = TaloPlayerAlias.new(alias)
 	_save_session(session_token, refresh_token)
-	Talo.players.identified.emit(Talo.current_player)
+	Talo.players.identified.emit(Talo.current_alias)
 	Talo.socket.set_socket_token(socket_token)
 
 func handle_session_refreshed(session_token: String, refresh_token: String) -> void:
@@ -93,4 +93,4 @@ func handle_identifier_changed(alias: TaloPlayerAlias) -> void:
 func handle_account_migrated(alias: TaloPlayerAlias) -> void:
 	clear_session(false)
 	_set_new_alias(alias)
-	Talo.players.identified.emit(Talo.current_player)
+	Talo.players.identified.emit(Talo.current_alias)

--- a/test/apis/players/identify_offline_test.gd
+++ b/test/apis/players/identify_offline_test.gd
@@ -24,30 +24,30 @@ func after_test() -> void:
 	DirAccess.remove_absolute(TaloPlayerAlias._OFFLINE_DATA_PATH)
 
 func test_identifies_player_when_offline_with_matching_alias() -> void:
-	var alias := TaloFixtures.make_alias({
+	var offline_alias := TaloFixtures.make_alias({
 		"player_alias": {
 			"service": "talo",
 			"identifier": "player1"
 		}
 	})
-	alias.write_offline_alias()
+	offline_alias.write_offline_alias()
 
-	var player := await Talo.players.identify_offline("talo", "player1")
+	var alias := await Talo.players.identify_offline("talo", "player1")
 
-	assert_object(player).is_not_null()
+	assert_object(alias).is_not_null()
 	assert_object(Talo.current_alias).is_not_null()
 	assert_str(Talo.current_alias.identifier).is_equal("player1")
 
 func test_does_not_set_the_alias_on_request_mismatch() -> void:
-	var alias := TaloFixtures.make_alias({
+	var offline_alias := TaloFixtures.make_alias({
 		"player_alias": {
 			"service": "talo",
 			"identifier": "player1"
 		}
 	})
-	alias.write_offline_alias()
+	offline_alias.write_offline_alias()
 
-	var player := await Talo.players.identify_offline("talo", "wrong_player")
+	var alias := await Talo.players.identify_offline("talo", "wrong_player")
 
-	assert_object(player).is_null()
+	assert_object(alias).is_null()
 	assert_object(Talo.current_alias).is_null()


### PR DESCRIPTION
**Identification return type realignment**
- `PlayersAPI.identify()` and all platform-specific identify methods (`identify_steam`, `identify_google_play_games`, `identify_game_center`, `identify_offline`) now return `TaloPlayerAlias` instead of `TaloPlayer`
- The `identified` signal now passes a `TaloPlayerAlias` parameter rather than `TaloPlayer`
- `_handle_identify_success` return type updated to match

**Sample script migration from `current_player` to `current_alias`**
- All sample consume callbacks (authentication, chat, saves, playground) updated their `identified` signal handlers to accept `TaloPlayerAlias` instead of `TaloPlayer`
- References to `Talo.current_player` replaced with `Talo.current_alias` in samples where used after identification

**Session manager consistency**
- `handle_session_created` and `handle_account_migrated` now emit `identified` with `Talo.current_alias` instead of `Talo.current_player`, aligning the internal wiring with the updated signal signature