### PR TITLE
Return error code in identification_failed signal

### DIFF
--- a/addons/talo/apis/players_api.gd
+++ b/addons/talo/apis/players_api.gd
@@ -11,8 +11,8 @@ signal identified(player_alias: TaloPlayerAlias)
 ## Emitted when identification starts.
 signal identification_started()
 
-## Emitted when identification fails.
-signal identification_failed()
+## Emitted when identification fails with a [TaloIdentifyError].
+signal identification_failed(error: TaloIdentifyError)
 
 ## Emitted after calling clear_identity().
 signal identity_cleared()
@@ -56,7 +56,7 @@ func identify(service: String, identifier: String) -> TaloPlayerAlias:
 			return await _handle_identify_success(alias, res.body.socketToken)
 		_:
 			Talo.player_auth.session_manager.clear_session()
-			identification_failed.emit()
+			identification_failed.emit(TaloIdentifyError.from_response(res.body))
 			return null
 
 ## Identify a player using a Steam ticket.
@@ -153,7 +153,7 @@ func identify_offline(service: String, identifier: String) -> TaloPlayerAlias:
 	if offline_alias != null and offline_alias.matches_identify_request(service, identifier):
 		return await _handle_identify_success(offline_alias)
 	else:
-		identification_failed.emit()
+		identification_failed.emit(TaloIdentifyError.from_response(null))
 		return null
 
 ## Search for players by IDs, prop values and alias identifiers.

--- a/addons/talo/errors/identify_error.gd
+++ b/addons/talo/errors/identify_error.gd
@@ -1,0 +1,18 @@
+class_name TaloIdentifyError extends RefCounted
+
+enum ErrorCode {
+	UNKNOWN_ERROR,
+	IDENTIFIER_PROFANITY,
+	IDENTIFIER_TAKEN
+}
+
+var error: ErrorCode
+
+func _init(error_code: ErrorCode = ErrorCode.UNKNOWN_ERROR) -> void:
+	error = error_code
+
+static func from_response(body: Variant) -> TaloIdentifyError:
+	var code := ErrorCode.UNKNOWN_ERROR
+	if body is Dictionary and body.has("errorCode"):
+		code = ErrorCode.get(body.errorCode, ErrorCode.UNKNOWN_ERROR)
+	return TaloIdentifyError.new(code)

--- a/addons/talo/errors/identify_error.gd.uid
+++ b/addons/talo/errors/identify_error.gd.uid
@@ -1,0 +1,1 @@
+uid://dlxe3gptwxpsb


### PR DESCRIPTION
**Structured identify errors**

- The `identification_failed` signal now carries a `TaloIdentifyError` payload instead of firing without arguments, so consumers can inspect what went wrong.

- A new `TaloIdentifyError` class exposes an enum with specific error codes (`IDENTIFIER_PROFANITY`, `IDENTIFIER_TAKEN`, `UNKNOWN_ERROR`), parsed from the server response body or set to `UNKNOWN_ERROR` in the offline path.