### PR TITLE
Use from_response pattern for player_auth_error, remove accessor funcs

### DIFF
--- a/addons/talo/apis/player_auth_api.gd
+++ b/addons/talo/apis/player_auth_api.gd
@@ -22,11 +22,7 @@ var last_error: TaloPlayerAuthError = null
 var session_refresh_request: SessionRefreshRequest = null
 
 func _handle_error(res: Dictionary, ret: Variant = FAILED) -> Variant:
-	if res.body != null and res.body.has("errorCode"):
-		last_error = TaloPlayerAuthError.new(res.body.errorCode)
-	else:
-		last_error = TaloPlayerAuthError.new("API_ERROR")
-
+	last_error = TaloPlayerAuthError.from_response(res.body)
 	return ret
 
 ## Identify the player if they have a valid session.

--- a/addons/talo/errors/player_auth_error.gd
+++ b/addons/talo/errors/player_auth_error.gd
@@ -19,18 +19,24 @@ enum ErrorCode {
 	IDENTIFIER_PROFANITY
 }
 
-var _error_string := ""
+## The player auth error code, or [code]API_ERROR[/code] when missing/unknown.
+var error: ErrorCode
 
-func _init(error_string: String) -> void:
-	_error_string = error_string
+## The human-readable message from the response, or a fallback for API errors.
+var message: String
 
-## Get the human-readable player auth error message. 
-func get_string() -> String:
-	if _error_string == "API_ERROR":
-		return "API error - see the Errors Output for more details"
+func _init(error_code: ErrorCode = ErrorCode.API_ERROR, message: String = "") -> void:
+	error = error_code
+	self.message = message
 
-	return _error_string
+static func from_response(body: Variant) -> TaloPlayerAuthError:
+	var code := ErrorCode.API_ERROR
+	var message := "API error - see the Errors Output for more details"
+	if body is Dictionary:
+		if body.has("errorCode"):
+			code = ErrorCode.get(body.errorCode, ErrorCode.API_ERROR)
+			message = body.get("message", "Unknown error")
+		elif body.has("message"):
+			message = body.message
 
-## Get the player auth error code using the ErrorCode enum.
-func get_code() -> ErrorCode:
-	return ErrorCode.get(_error_string)
+	return TaloPlayerAuthError.new(code, message)

--- a/addons/talo/samples/authentication/scripts/change_email.gd
+++ b/addons/talo/samples/authentication/scripts/change_email.gd
@@ -20,7 +20,7 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.change_email(password.text, new_email.text)
 	if res != OK:
-		match Talo.player_auth.last_error.get_code():
+		match Talo.player_auth.last_error.error:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_EMAIL_MATCHES_CURRENT_EMAIL:
@@ -28,7 +28,7 @@ func _on_submit_pressed() -> void:
 			TaloPlayerAuthError.ErrorCode.INVALID_EMAIL:
 				validation_label.text = "Invalid email address"
 			_:
-				validation_label.text = Talo.player_auth.last_error.get_string()
+				validation_label.text = Talo.player_auth.last_error.message
 	else:
 		email_change_success.emit()
 

--- a/addons/talo/samples/authentication/scripts/change_identifier.gd
+++ b/addons/talo/samples/authentication/scripts/change_identifier.gd
@@ -20,7 +20,7 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.change_identifier(password.text, new_identifier.text)
 	if res != OK:
-		match Talo.player_auth.last_error.get_code():
+		match Talo.player_auth.last_error.error:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_IDENTIFIER_MATCHES_CURRENT_IDENTIFIER:
@@ -28,7 +28,7 @@ func _on_submit_pressed() -> void:
 			TaloPlayerAuthError.ErrorCode.IDENTIFIER_TAKEN:
 				validation_label.text = "Identifier is already taken"
 			_:
-				validation_label.text = Talo.player_auth.last_error.get_string()
+				validation_label.text = Talo.player_auth.last_error.message
 	else:
 		identifier_change_success.emit()
 

--- a/addons/talo/samples/authentication/scripts/change_password.gd
+++ b/addons/talo/samples/authentication/scripts/change_password.gd
@@ -20,13 +20,13 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.change_password(current_password.text, new_password.text)
 	if res != OK:
-		match Talo.player_auth.last_error.get_code():
+		match Talo.player_auth.last_error.error:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_PASSWORD_MATCHES_CURRENT_PASSWORD:
 				validation_label.text = "New password must be different from the current password"
 			_:
-				validation_label.text = Talo.player_auth.last_error.get_string()
+				validation_label.text = Talo.player_auth.last_error.message
 	else:
 		password_change_success.emit()
 

--- a/addons/talo/samples/authentication/scripts/delete_account.gd
+++ b/addons/talo/samples/authentication/scripts/delete_account.gd
@@ -15,11 +15,11 @@ func _on_delete_pressed() -> void:
 
 	var res := await Talo.player_auth.delete_account(current_password.text)
 	if res != OK:
-		match Talo.player_auth.last_error.get_code():
+		match Talo.player_auth.last_error.error:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			_:
-				validation_label.text = Talo.player_auth.last_error.get_string()
+				validation_label.text = Talo.player_auth.last_error.message
 	else:
 		delete_account_success.emit()
 

--- a/addons/talo/samples/authentication/scripts/login.gd
+++ b/addons/talo/samples/authentication/scripts/login.gd
@@ -22,11 +22,11 @@ func _on_submit_pressed() -> void:
 	var res := await Talo.player_auth.login(username.text, password.text)
 	match res:
 		Talo.player_auth.LoginResult.FAILED:
-			match Talo.player_auth.last_error.get_code():
+			match Talo.player_auth.last_error.error:
 				TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 					validation_label.text = "Username or password is incorrect"
 				_:
-					validation_label.text = Talo.player_auth.last_error.get_string()
+					validation_label.text = Talo.player_auth.last_error.message
 		Talo.player_auth.LoginResult.VERIFICATION_REQUIRED:
 			verification_required.emit()
 		Talo.player_auth.LoginResult.OK:

--- a/addons/talo/samples/authentication/scripts/register.gd
+++ b/addons/talo/samples/authentication/scripts/register.gd
@@ -25,13 +25,13 @@ func _on_submit_button_pressed() -> void:
 
 	var res := await Talo.player_auth.register(username.text, password.text, email.text, enable_verification.button_pressed)
 	if res != OK:
-		match Talo.player_auth.last_error.get_code():
+		match Talo.player_auth.last_error.error:
 			TaloPlayerAuthError.ErrorCode.IDENTIFIER_TAKEN:
 				validation_label.text = "Username is already taken"
 			TaloPlayerAuthError.ErrorCode.INVALID_EMAIL:
 				validation_label.text = "Invalid email address"
 			_:
-				validation_label.text = Talo.player_auth.last_error.get_string()
+				validation_label.text = Talo.player_auth.last_error.message
 
 func _on_login_pressed() -> void:
 	go_to_login.emit()

--- a/addons/talo/samples/authentication/scripts/reset_password.gd
+++ b/addons/talo/samples/authentication/scripts/reset_password.gd
@@ -20,11 +20,11 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.reset_password(code.text, new_password.text)
 	if res != OK:
-		match Talo.player_auth.last_error.get_code():
+		match Talo.player_auth.last_error.error:
 			TaloPlayerAuthError.ErrorCode.PASSWORD_RESET_CODE_INVALID:
 				validation_label.text = "Reset code is invalid"
 			_:
-				validation_label.text = Talo.player_auth.last_error.get_string()
+				validation_label.text = Talo.player_auth.last_error.message
 	else:
 		password_reset_success.emit()
 

--- a/addons/talo/samples/authentication/scripts/verify.gd
+++ b/addons/talo/samples/authentication/scripts/verify.gd
@@ -12,10 +12,10 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.verify(code.text)
 	if res != OK:
-		match Talo.player_auth.last_error.get_code():
+		match Talo.player_auth.last_error.error:
 			TaloPlayerAuthError.ErrorCode.VERIFICATION_CODE_INVALID:
 				validation_label.text = "Verification code is incorrect"
 			TaloPlayerAuthError.ErrorCode.VERIFICATION_ALIAS_NOT_FOUND:
 				validation_label.text = "Verification session is invalid"
 			_:
-				validation_label.text = Talo.player_auth.last_error.get_string()
+				validation_label.text = Talo.player_auth.last_error.message

--- a/addons/talo/talo_client.gd
+++ b/addons/talo/talo_client.gd
@@ -33,8 +33,7 @@ func _attempt_refresh(url: String, body: Dictionary) -> Error:
 	if Talo.current_alias == null or url.ends_with("/v1/players/auth/refresh") or not body.has("errorCode"):
 		return ERR_SKIP
 
-	var error := TaloPlayerAuthError.new(body["errorCode"])
-	if error.get_code() != TaloPlayerAuthError.ErrorCode.INVALID_SESSION:
+	if TaloPlayerAuthError.ErrorCode.get(body.errorCode) != TaloPlayerAuthError.ErrorCode.INVALID_SESSION:
 		return ERR_SKIP
 
 	return await Talo.player_auth.refresh()

--- a/test/errors/player_auth_error_test.gd
+++ b/test/errors/player_auth_error_test.gd
@@ -1,0 +1,41 @@
+extends GdUnitTestSuite
+
+func test_from_response_with_error_code_and_message_uses_both() -> void:
+	var err := TaloPlayerAuthError.from_response({
+		errorCode = "INVALID_CREDENTIALS",
+		message = "Current password is incorrect"
+	})
+
+	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS)
+	assert_str(err.message).is_equal("Current password is incorrect")
+
+func test_from_response_with_error_code_only_uses_unknown_error_message() -> void:
+	var err := TaloPlayerAuthError.from_response({
+		errorCode = "INVALID_CREDENTIALS"
+	})
+
+	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS)
+	assert_str(err.message).is_equal("Unknown error")
+
+func test_from_response_with_message_only_falls_back_to_api_error_code() -> void:
+	var err := TaloPlayerAuthError.from_response({
+		message = "Something went wrong"
+	})
+
+	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
+	assert_str(err.message).is_equal("Something went wrong")
+
+func test_from_response_with_null_body_uses_api_error_defaults() -> void:
+	var err := TaloPlayerAuthError.from_response(null)
+
+	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
+	assert_str(err.message).is_equal("API error - see the Errors Output for more details")
+
+func test_from_response_with_unknown_error_code_falls_back_to_api_error() -> void:
+	var err := TaloPlayerAuthError.from_response({
+		errorCode = "NOPE",
+		message = "some message"
+	})
+
+	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
+	assert_str(err.message).is_equal("some message")

--- a/test/errors/player_auth_error_test.gd.uid
+++ b/test/errors/player_auth_error_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cgt7j3nshmyan


### PR DESCRIPTION
**Error type overhaul**
- Replaced the string-based `TaloPlayerAuthError` with a typed `ErrorCode` enum property and a human-readable `message` string, removing the old `get_code()` / `get_string()` getter methods
- Added a static `from_response(body)` factory that parses both `errorCode` and `message` from API responses, gracefully handling missing/null bodies and unknown codes

**Consumer simplification**
- `player_auth_api.gd` delegates error construction entirely to `TaloPlayerAuthError.from_response()` instead of manually checking `res.body` for error data
- `talo_client.gd` uses `ErrorCode.get()` directly on the response body rather than instantiating a full error object just to check for `INVALID_SESSION`

**Sample code migration**
- All authentication sample scripts (`login`, `register`, `verify`, `change_email`, `change_identifier`, `change_password`, `delete_account`, `reset_password`) now reference `last_error.error` (the enum) and `last_error.message` (the string) instead of the removed getter methods, with no behavioural change to the user-facing validation labels