### PR TITLE
rename 'error' to 'code' across auth, identify and prop rejection

### DIFF
--- a/addons/talo/errors/identify_error.gd
+++ b/addons/talo/errors/identify_error.gd
@@ -6,10 +6,10 @@ enum ErrorCode {
 	IDENTIFIER_TAKEN
 }
 
-var error: ErrorCode
+var code: ErrorCode
 
-func _init(error_code: ErrorCode = ErrorCode.UNKNOWN_ERROR) -> void:
-	error = error_code
+func _init(code: ErrorCode = ErrorCode.UNKNOWN_ERROR) -> void:
+	self.code = code
 
 static func from_response(body: Variant) -> TaloIdentifyError:
 	var code := ErrorCode.UNKNOWN_ERROR

--- a/addons/talo/errors/player_auth_error.gd
+++ b/addons/talo/errors/player_auth_error.gd
@@ -20,15 +20,16 @@ enum ErrorCode {
 }
 
 ## The player auth error code, or [code]API_ERROR[/code] when missing/unknown.
-var error: ErrorCode
+var code: ErrorCode
 
 ## The human-readable message from the response, or a fallback for API errors.
 var message: String
 
-func _init(error_code: ErrorCode = ErrorCode.API_ERROR, message: String = "") -> void:
-	error = error_code
+func _init(code: ErrorCode = ErrorCode.API_ERROR, message: String = "") -> void:
+	self.code = code
 	self.message = message
 
+## Build a [TaloPlayerAuthError] from a parsed response body.
 static func from_response(body: Variant) -> TaloPlayerAuthError:
 	var code := ErrorCode.API_ERROR
 	var message := "API error - see the Errors Output for more details"

--- a/addons/talo/errors/rejected_prop.gd
+++ b/addons/talo/errors/rejected_prop.gd
@@ -1,6 +1,6 @@
 class_name TaloRejectedProp extends RefCounted
 
-enum RejectionReason {
+enum ErrorCode {
 	UNKNOWN_ERROR,
 	PROP_KEY_TOO_LONG,
 	PROP_VALUE_TOO_LONG,
@@ -9,18 +9,18 @@ enum RejectionReason {
 	PROP_KEY_RESERVED
 }
 
-# Which prop key was rejected
+# Which prop key was rejected.
 var key: String
 
-# The rejection reason error code
-var error: RejectionReason
+# The rejection reason code using the [code]ErrorCode[/code] enum.
+var code: ErrorCode
 
-# The human-readable rejection reason
+# The human-readable rejection reason.
 var message: String
 
 func _init(data: Dictionary) -> void:
 	key = data.key
-	error = RejectionReason.get(data.error, RejectionReason.UNKNOWN_ERROR)
+	code = ErrorCode.get(data.error, ErrorCode.UNKNOWN_ERROR)
 	message = data.message
 
 static func from_response(body: Dictionary) -> Array[TaloRejectedProp]:

--- a/addons/talo/errors/socket_error.gd
+++ b/addons/talo/errors/socket_error.gd
@@ -17,7 +17,7 @@ enum ErrorCode {
 ## The original req that triggered the error.
 var req: String
 
-## The socket error code using the ErrorCode enum.
+## The socket error code using the [code]ErrorCode[/code] enum.
 var code: ErrorCode
 
 ## The human-readable socket error message. 

--- a/addons/talo/samples/authentication/scripts/change_email.gd
+++ b/addons/talo/samples/authentication/scripts/change_email.gd
@@ -20,7 +20,7 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.change_email(password.text, new_email.text)
 	if res != OK:
-		match Talo.player_auth.last_error.error:
+		match Talo.player_auth.last_error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_EMAIL_MATCHES_CURRENT_EMAIL:

--- a/addons/talo/samples/authentication/scripts/change_identifier.gd
+++ b/addons/talo/samples/authentication/scripts/change_identifier.gd
@@ -20,7 +20,7 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.change_identifier(password.text, new_identifier.text)
 	if res != OK:
-		match Talo.player_auth.last_error.error:
+		match Talo.player_auth.last_error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_IDENTIFIER_MATCHES_CURRENT_IDENTIFIER:

--- a/addons/talo/samples/authentication/scripts/change_password.gd
+++ b/addons/talo/samples/authentication/scripts/change_password.gd
@@ -20,7 +20,7 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.change_password(current_password.text, new_password.text)
 	if res != OK:
-		match Talo.player_auth.last_error.error:
+		match Talo.player_auth.last_error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_PASSWORD_MATCHES_CURRENT_PASSWORD:

--- a/addons/talo/samples/authentication/scripts/delete_account.gd
+++ b/addons/talo/samples/authentication/scripts/delete_account.gd
@@ -15,7 +15,7 @@ func _on_delete_pressed() -> void:
 
 	var res := await Talo.player_auth.delete_account(current_password.text)
 	if res != OK:
-		match Talo.player_auth.last_error.error:
+		match Talo.player_auth.last_error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			_:

--- a/addons/talo/samples/authentication/scripts/login.gd
+++ b/addons/talo/samples/authentication/scripts/login.gd
@@ -22,7 +22,7 @@ func _on_submit_pressed() -> void:
 	var res := await Talo.player_auth.login(username.text, password.text)
 	match res:
 		Talo.player_auth.LoginResult.FAILED:
-			match Talo.player_auth.last_error.error:
+			match Talo.player_auth.last_error.code:
 				TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 					validation_label.text = "Username or password is incorrect"
 				_:

--- a/addons/talo/samples/authentication/scripts/register.gd
+++ b/addons/talo/samples/authentication/scripts/register.gd
@@ -25,7 +25,7 @@ func _on_submit_button_pressed() -> void:
 
 	var res := await Talo.player_auth.register(username.text, password.text, email.text, enable_verification.button_pressed)
 	if res != OK:
-		match Talo.player_auth.last_error.error:
+		match Talo.player_auth.last_error.code:
 			TaloPlayerAuthError.ErrorCode.IDENTIFIER_TAKEN:
 				validation_label.text = "Username is already taken"
 			TaloPlayerAuthError.ErrorCode.INVALID_EMAIL:

--- a/addons/talo/samples/authentication/scripts/reset_password.gd
+++ b/addons/talo/samples/authentication/scripts/reset_password.gd
@@ -20,7 +20,7 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.reset_password(code.text, new_password.text)
 	if res != OK:
-		match Talo.player_auth.last_error.error:
+		match Talo.player_auth.last_error.code:
 			TaloPlayerAuthError.ErrorCode.PASSWORD_RESET_CODE_INVALID:
 				validation_label.text = "Reset code is invalid"
 			_:

--- a/addons/talo/samples/authentication/scripts/verify.gd
+++ b/addons/talo/samples/authentication/scripts/verify.gd
@@ -12,7 +12,7 @@ func _on_submit_pressed() -> void:
 
 	var res := await Talo.player_auth.verify(code.text)
 	if res != OK:
-		match Talo.player_auth.last_error.error:
+		match Talo.player_auth.last_error.code:
 			TaloPlayerAuthError.ErrorCode.VERIFICATION_CODE_INVALID:
 				validation_label.text = "Verification code is incorrect"
 			TaloPlayerAuthError.ErrorCode.VERIFICATION_ALIAS_NOT_FOUND:

--- a/test/errors/player_auth_error_test.gd
+++ b/test/errors/player_auth_error_test.gd
@@ -6,7 +6,7 @@ func test_from_response_with_error_code_and_message_uses_both() -> void:
 		message = "Current password is incorrect"
 	})
 
-	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS)
+	assert_int(err.code).is_equal(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS)
 	assert_str(err.message).is_equal("Current password is incorrect")
 
 func test_from_response_with_error_code_only_uses_unknown_error_message() -> void:
@@ -14,7 +14,7 @@ func test_from_response_with_error_code_only_uses_unknown_error_message() -> voi
 		errorCode = "INVALID_CREDENTIALS"
 	})
 
-	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS)
+	assert_int(err.code).is_equal(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS)
 	assert_str(err.message).is_equal("Unknown error")
 
 func test_from_response_with_message_only_falls_back_to_api_error_code() -> void:
@@ -22,13 +22,13 @@ func test_from_response_with_message_only_falls_back_to_api_error_code() -> void
 		message = "Something went wrong"
 	})
 
-	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
+	assert_int(err.code).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
 	assert_str(err.message).is_equal("Something went wrong")
 
 func test_from_response_with_null_body_uses_api_error_defaults() -> void:
 	var err := TaloPlayerAuthError.from_response(null)
 
-	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
+	assert_int(err.code).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
 	assert_str(err.message).is_equal("API error - see the Errors Output for more details")
 
 func test_from_response_with_unknown_error_code_falls_back_to_api_error() -> void:
@@ -37,5 +37,5 @@ func test_from_response_with_unknown_error_code_falls_back_to_api_error() -> voi
 		message = "some message"
 	})
 
-	assert_int(err.error).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
+	assert_int(err.code).is_equal(TaloPlayerAuthError.ErrorCode.API_ERROR)
 	assert_str(err.message).is_equal("some message")


### PR DESCRIPTION
**Error property standardisation**
- Renamed the `.error` property to `.code` on `TaloIdentifyError`, `TaloPlayerAuthError`, `TaloRejectedProp`, and `TaloSocketError` so every error class accesses its machine-readable enum via the same name
- Renamed `TaloRejectedProp.RejectionReason` to `TaloRejectedProp.ErrorCode` to match the naming convention used by every other error class

**Consumer alignment**
- Updated all sample authentication scripts (login, register, verify, change email/identifier/password, delete account, reset password) to reference `last_error.code` instead of the old `last_error.error`