### PR TITLE
Replace Talo.player_auth.last_error with an inline structured response

### DIFF
--- a/addons/talo/apis/player_auth_api.gd
+++ b/addons/talo/apis/player_auth_api.gd
@@ -5,12 +5,6 @@ class_name PlayerAuthAPI extends TaloAPI
 ##
 ## @tutorial: https://docs.trytalo.com/docs/godot/player-authentication
 
-enum LoginResult {
-	OK,
-	FAILED,
-	VERIFICATION_REQUIRED,
-}
-
 ## Emitted when Talo.player_auth.start_session() is called and a valid session is found.
 signal session_found()
 
@@ -18,12 +12,7 @@ signal session_found()
 signal session_not_found()
 
 var session_manager := TaloSessionManager.new()
-var last_error: TaloPlayerAuthError = null
 var session_refresh_request: SessionRefreshRequest = null
-
-func _handle_error(res: Dictionary, ret: Variant = FAILED) -> Variant:
-	last_error = TaloPlayerAuthError.from_response(res.body)
-	return ret
 
 ## Identify the player if they have a valid session.
 func start_session() -> void:
@@ -34,10 +23,11 @@ func start_session() -> void:
 		session_not_found.emit()
 
 ## Register a new player account. If verification is enabled, a valid email will be required to verify all logins.
-func register(identifier: String, password: String, email: String = "", verification_enabled: bool = false) -> Error:
+func register(identifier: String, password: String, email: String = "", verification_enabled: bool = false) -> PlayerAuthResult:
 	if verification_enabled and email.is_empty():
 		push_error("Email is required when verification is enabled")
-		return FAILED
+		var error := TaloPlayerAuthError.from_response({ message = "Email is required when verification is enabled" })
+		return PlayerAuthResult.new(error)
 
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/register", {
 		identifier = identifier,
@@ -55,12 +45,12 @@ func register(identifier: String, password: String, email: String = "", verifica
 				res.body.refreshToken,
 				res.body.socketToken
 			)
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Log in to an existing player account. If verification is required, a verification code will be sent to the player's email.
-func login(identifier: String, password: String) -> LoginResult:
+func login(identifier: String, password: String) -> PlayerAuthLoginResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/login", {
 		identifier = identifier,
 		password = password,
@@ -69,7 +59,8 @@ func login(identifier: String, password: String) -> LoginResult:
 
 	match res.status:
 		200:
-			if res.body.has("verificationRequired"):
+			var verification_required: bool = res.body.get("verificationRequired", false)
+			if verification_required:
 				session_manager.save_verification_alias_id(res.body.aliasId)
 			else:
 				session_manager.handle_session_created(
@@ -79,15 +70,12 @@ func login(identifier: String, password: String) -> LoginResult:
 					res.body.socketToken
 				)
 
-			if res.body.has("verificationRequired"):
-				return LoginResult.VERIFICATION_REQUIRED
-			else:
-				return LoginResult.OK
+			return PlayerAuthLoginResult.new(null, verification_required)
 		_:
-			return _handle_error(res, LoginResult.FAILED)
+			return PlayerAuthLoginResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Verify a player account using the verification code sent to the player's email.
-func verify(verification_code: String) -> Error:
+func verify(verification_code: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/verify", {
 		aliasId = session_manager.get_verification_alias_id(),
 		code = verification_code,
@@ -102,9 +90,9 @@ func verify(verification_code: String) -> Error:
 				res.body.refreshToken,
 				res.body.socketToken
 			)
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Log out of the current player account.
 func logout() -> void:
@@ -112,10 +100,11 @@ func logout() -> void:
 	session_manager.clear_session()
 
 ## Refresh the current session.
-func refresh() -> Error:
+func refresh() -> PlayerAuthResult:
 	var refresh_token := session_manager.get_refresh_token()
 	if refresh_token.is_empty():
-		return FAILED
+		var error := TaloPlayerAuthError.from_response({ message = "No refresh token available" })
+		return PlayerAuthResult.new()
 
 	if session_refresh_request != null:
 		return await session_refresh_request.completed
@@ -125,20 +114,21 @@ func refresh() -> Error:
 		refreshToken = refresh_token
 	})
 
-	var result := OK
+	var result: PlayerAuthResult
 	match res.status:
 		200:
 			session_manager.handle_session_refreshed(res.body.sessionToken, res.body.refreshToken)
+			result = PlayerAuthResult.new()
 		_:
 			session_manager.clear_session()
-			result = _handle_error(res)
+			result = PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 	session_refresh_request.completed.emit(result)
 	session_refresh_request = null
 	return result
 
 ## Change the password of the current player account.
-func change_password(current_password: String, new_password: String) -> Error:
+func change_password(current_password: String, new_password: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/change_password", {
 		currentPassword = current_password,
 		newPassword = new_password
@@ -146,12 +136,12 @@ func change_password(current_password: String, new_password: String) -> Error:
 
 	match res.status:
 		204:
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Change the email of the current player account.
-func change_email(current_password: String, new_email: String) -> Error:
+func change_email(current_password: String, new_email: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/change_email", {
 		currentPassword = current_password,
 		newEmail = new_email
@@ -159,12 +149,12 @@ func change_email(current_password: String, new_email: String) -> Error:
 
 	match res.status:
 		204:
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Change the identifier of the current player alias.
-func change_identifier(current_password: String, new_identifier: String) -> Error:
+func change_identifier(current_password: String, new_identifier: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/change_identifier", {
 		currentPassword = current_password,
 		newIdentifier = new_identifier
@@ -173,24 +163,24 @@ func change_identifier(current_password: String, new_identifier: String) -> Erro
 	match res.status:
 		200:
 			session_manager.handle_identifier_changed(TaloPlayerAlias.new(res.body.alias))
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Send a password reset email to the player's email.
-func forgot_password(email: String) -> Error:
+func forgot_password(email: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/forgot_password", {
 		email = email
 	})
 
 	match res.status:
 		204:
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Reset the password of the player account using the code sent to the player's email.
-func reset_password(code: String, password: String) -> Error:
+func reset_password(code: String, password: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/reset_password", {
 		code = code,
 		password = password
@@ -198,12 +188,12 @@ func reset_password(code: String, password: String) -> Error:
 
 	match res.status:
 		204:
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Toggle email verification for the current player account.
-func toggle_verification(current_password: String, verification_enabled: bool, email: String = "") -> Error:
+func toggle_verification(current_password: String, verification_enabled: bool, email: String = "") -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_PATCH, "/toggle_verification", {
 		currentPassword = current_password,
 		verificationEnabled = verification_enabled,
@@ -212,12 +202,12 @@ func toggle_verification(current_password: String, verification_enabled: bool, e
 
 	match res.status:
 		204:
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Delete the current player account.
-func delete_account(current_password: String) -> Error:
+func delete_account(current_password: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_DELETE, "/", {
 		currentPassword = current_password
 	})
@@ -225,12 +215,12 @@ func delete_account(current_password: String) -> Error:
 	match res.status:
 		204:
 			session_manager.clear_session()
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
 
 ## Migrate the current player account to a different service and identifier.
-func migrate_account(current_password: String, new_service: String, new_identifier: String) -> Error:
+func migrate_account(current_password: String, new_service: String, new_identifier: String) -> PlayerAuthResult:
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/migrate", {
 		currentPassword = current_password,
 		service = new_service,
@@ -240,9 +230,25 @@ func migrate_account(current_password: String, new_service: String, new_identifi
 	match res.status:
 		200:
 			session_manager.handle_account_migrated(TaloPlayerAlias.new(res.body.alias))
-			return OK
+			return PlayerAuthResult.new()
 		_:
-			return _handle_error(res)
+			return PlayerAuthResult.new(TaloPlayerAuthError.from_response(res.body))
+
+class PlayerAuthResult:
+	var error: TaloPlayerAuthError = null
+
+	var success: bool:
+		get: return error == null
+
+	func _init(error: TaloPlayerAuthError = null) -> void:
+		self.error = error
+
+class PlayerAuthLoginResult extends PlayerAuthResult:
+	var verification_required: bool = false
+
+	func _init(error: TaloPlayerAuthError = null, verification_required: bool = false) -> void:
+		super(error)
+		self.verification_required = verification_required
 
 class SessionRefreshRequest extends RefCounted:
-	signal completed(result: Error)
+	signal completed(result: PlayerAuthResult)

--- a/addons/talo/samples/authentication/scripts/change_email.gd
+++ b/addons/talo/samples/authentication/scripts/change_email.gd
@@ -19,8 +19,10 @@ func _on_submit_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.change_email(password.text, new_email.text)
-	if res != OK:
-		match Talo.player_auth.last_error.code:
+	if res.success:
+		email_change_success.emit()
+	else:
+		match res.error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_EMAIL_MATCHES_CURRENT_EMAIL:
@@ -28,9 +30,7 @@ func _on_submit_pressed() -> void:
 			TaloPlayerAuthError.ErrorCode.INVALID_EMAIL:
 				validation_label.text = "Invalid email address"
 			_:
-				validation_label.text = Talo.player_auth.last_error.message
-	else:
-		email_change_success.emit()
+				validation_label.text = res.error.message
 
 func _on_cancel_pressed() -> void:
 	go_to_game.emit()

--- a/addons/talo/samples/authentication/scripts/change_identifier.gd
+++ b/addons/talo/samples/authentication/scripts/change_identifier.gd
@@ -19,8 +19,10 @@ func _on_submit_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.change_identifier(password.text, new_identifier.text)
-	if res != OK:
-		match Talo.player_auth.last_error.code:
+	if res.success:
+		identifier_change_success.emit()
+	else:
+		match res.error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_IDENTIFIER_MATCHES_CURRENT_IDENTIFIER:
@@ -28,9 +30,7 @@ func _on_submit_pressed() -> void:
 			TaloPlayerAuthError.ErrorCode.IDENTIFIER_TAKEN:
 				validation_label.text = "Identifier is already taken"
 			_:
-				validation_label.text = Talo.player_auth.last_error.message
-	else:
-		identifier_change_success.emit()
+				validation_label.text = res.error.message
 
 func _on_cancel_pressed() -> void:
 	go_to_game.emit()

--- a/addons/talo/samples/authentication/scripts/change_password.gd
+++ b/addons/talo/samples/authentication/scripts/change_password.gd
@@ -19,16 +19,16 @@ func _on_submit_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.change_password(current_password.text, new_password.text)
-	if res != OK:
-		match Talo.player_auth.last_error.code:
+	if res.success:
+		password_change_success.emit()
+	else:
+		match res.error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			TaloPlayerAuthError.ErrorCode.NEW_PASSWORD_MATCHES_CURRENT_PASSWORD:
 				validation_label.text = "New password must be different from the current password"
 			_:
-				validation_label.text = Talo.player_auth.last_error.message
-	else:
-		password_change_success.emit()
+				validation_label.text = res.error.message
 
 func _on_cancel_pressed() -> void:
 	go_to_game.emit()

--- a/addons/talo/samples/authentication/scripts/delete_account.gd
+++ b/addons/talo/samples/authentication/scripts/delete_account.gd
@@ -14,14 +14,14 @@ func _on_delete_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.delete_account(current_password.text)
-	if res != OK:
-		match Talo.player_auth.last_error.code:
+	if res.success:
+		delete_account_success.emit()
+	else:
+		match res.error.code:
 			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
 				validation_label.text = "Current password is incorrect"
 			_:
-				validation_label.text = Talo.player_auth.last_error.message
-	else:
-		delete_account_success.emit()
+				validation_label.text = res.error.message
 
 func _on_cancel_pressed() -> void:
 	go_to_game.emit()

--- a/addons/talo/samples/authentication/scripts/forgot_password.gd
+++ b/addons/talo/samples/authentication/scripts/forgot_password.gd
@@ -13,7 +13,8 @@ func _on_submit_pressed() -> void:
 		validation_label.text = "Email is required"
 		return
 
-	if await Talo.player_auth.forgot_password(email.text) == OK:
+	var res := await Talo.player_auth.forgot_password(email.text)
+	if res.success:
 		forgot_password_success.emit()
 
 func _on_cancel_pressed() -> void:

--- a/addons/talo/samples/authentication/scripts/login.gd
+++ b/addons/talo/samples/authentication/scripts/login.gd
@@ -20,17 +20,14 @@ func _on_submit_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.login(username.text, password.text)
-	match res:
-		Talo.player_auth.LoginResult.FAILED:
-			match Talo.player_auth.last_error.code:
-				TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
-					validation_label.text = "Username or password is incorrect"
-				_:
-					validation_label.text = Talo.player_auth.last_error.message
-		Talo.player_auth.LoginResult.VERIFICATION_REQUIRED:
-			verification_required.emit()
-		Talo.player_auth.LoginResult.OK:
-			pass
+	if res.verification_required:
+		verification_required.emit()
+	elif not res.success:
+		match res.error.code:
+			TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS:
+				validation_label.text = "Username or password is incorrect"
+			_:
+				validation_label.text = res.error.message
 
 func _on_forgot_password_pressed() -> void:
 	go_to_forgot_password.emit()

--- a/addons/talo/samples/authentication/scripts/register.gd
+++ b/addons/talo/samples/authentication/scripts/register.gd
@@ -24,14 +24,14 @@ func _on_submit_button_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.register(username.text, password.text, email.text, enable_verification.button_pressed)
-	if res != OK:
-		match Talo.player_auth.last_error.code:
+	if not res.success:
+		match res.error.code:
 			TaloPlayerAuthError.ErrorCode.IDENTIFIER_TAKEN:
 				validation_label.text = "Username is already taken"
 			TaloPlayerAuthError.ErrorCode.INVALID_EMAIL:
 				validation_label.text = "Invalid email address"
 			_:
-				validation_label.text = Talo.player_auth.last_error.message
+				validation_label.text = res.error.message
 
 func _on_login_pressed() -> void:
 	go_to_login.emit()

--- a/addons/talo/samples/authentication/scripts/reset_password.gd
+++ b/addons/talo/samples/authentication/scripts/reset_password.gd
@@ -19,14 +19,14 @@ func _on_submit_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.reset_password(code.text, new_password.text)
-	if res != OK:
-		match Talo.player_auth.last_error.code:
+	if res.success:
+		password_reset_success.emit()
+	else:
+		match res.error.code:
 			TaloPlayerAuthError.ErrorCode.PASSWORD_RESET_CODE_INVALID:
 				validation_label.text = "Reset code is invalid"
 			_:
-				validation_label.text = Talo.player_auth.last_error.message
-	else:
-		password_reset_success.emit()
+				validation_label.text = res.error.message
 
 func _on_cancel_pressed() -> void:
 	go_to_forgot_password.emit()

--- a/addons/talo/samples/authentication/scripts/verify.gd
+++ b/addons/talo/samples/authentication/scripts/verify.gd
@@ -11,11 +11,11 @@ func _on_submit_pressed() -> void:
 		return
 
 	var res := await Talo.player_auth.verify(code.text)
-	if res != OK:
-		match Talo.player_auth.last_error.code:
+	if not res.success:
+		match res.error.code:
 			TaloPlayerAuthError.ErrorCode.VERIFICATION_CODE_INVALID:
 				validation_label.text = "Verification code is incorrect"
 			TaloPlayerAuthError.ErrorCode.VERIFICATION_ALIAS_NOT_FOUND:
 				validation_label.text = "Verification session is invalid"
 			_:
-				validation_label.text = Talo.player_auth.last_error.message
+				validation_label.text = res.error.message

--- a/addons/talo/talo_client.gd
+++ b/addons/talo/talo_client.gd
@@ -36,7 +36,8 @@ func _attempt_refresh(url: String, body: Dictionary) -> Error:
 	if TaloPlayerAuthError.ErrorCode.get(body.errorCode) != TaloPlayerAuthError.ErrorCode.INVALID_SESSION:
 		return ERR_SKIP
 
-	return await Talo.player_auth.refresh()
+	var res := await Talo.player_auth.refresh()
+	return OK if res.success else FAILED
 
 func make_request(
 	method: HTTPClient.Method,

--- a/addons/talo/utils/session_manager.gd
+++ b/addons/talo/utils/session_manager.gd
@@ -77,7 +77,8 @@ func check_for_session() -> bool:
 	if get_refresh_token().is_empty():
 		return false
 
-	return await Talo.player_auth.refresh() == OK
+	var res := await Talo.player_auth.refresh()
+	return res.success
 
 func _set_new_alias(alias: TaloPlayerAlias) -> void:
 	Talo.current_alias = alias

--- a/test/apis/player_auth/player_auth_result_test.gd
+++ b/test/apis/player_auth/player_auth_result_test.gd
@@ -1,0 +1,36 @@
+extends GdUnitTestSuite
+
+func test_player_auth_result_with_no_error_is_success() -> void:
+	var result := PlayerAuthAPI.PlayerAuthResult.new()
+
+	assert_bool(result.success).is_true()
+	assert_object(result.error).is_null()
+
+func test_player_auth_result_with_error_is_failure() -> void:
+	var err := TaloPlayerAuthError.new(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS, "nope")
+	var result := PlayerAuthAPI.PlayerAuthResult.new(err)
+
+	assert_bool(result.success).is_false()
+	assert_object(result.error).is_same(err)
+
+func test_player_auth_login_result_with_no_error_is_success() -> void:
+	var result := PlayerAuthAPI.PlayerAuthLoginResult.new()
+
+	assert_bool(result.success).is_true()
+	assert_bool(result.verification_required).is_false()
+	assert_object(result.error).is_null()
+
+func test_player_auth_login_result_with_verification_required_is_success() -> void:
+	var result := PlayerAuthAPI.PlayerAuthLoginResult.new(null, true)
+
+	assert_bool(result.success).is_true()
+	assert_bool(result.verification_required).is_true()
+	assert_object(result.error).is_null()
+
+func test_player_auth_login_result_with_error_defaults_to_no_verification() -> void:
+	var err := TaloPlayerAuthError.new(TaloPlayerAuthError.ErrorCode.INVALID_CREDENTIALS, "nope")
+	var result := PlayerAuthAPI.PlayerAuthLoginResult.new(err)
+
+	assert_bool(result.success).is_false()
+	assert_bool(result.verification_required).is_false()
+	assert_object(result.error).is_same(err)

--- a/test/apis/player_auth/player_auth_result_test.gd.uid
+++ b/test/apis/player_auth/player_auth_result_test.gd.uid
@@ -1,0 +1,1 @@
+uid://diwvpw8o3p5k


### PR DESCRIPTION
**Result object pattern**

- All authentication methods (`register`, `login`, `verify`, `refresh`, `change_password`, `change_email`, `change_identifier`, `forgot_password`, `reset_password`, `toggle_verification`, `delete_account`, `migrate_account`) now return `PlayerAuthResult` (or `PlayerAuthLoginResult` for `login`) instead of bare `Error` codes or the custom `LoginResult` enum
- The new classes expose a `success` boolean (true when `error` is null) and carry an optional `TaloPlayerAuthError`, so callers no longer need to cross-reference a separate `last_error` property
- `PlayerAuthLoginResult` additionally exposes a `verification_required` boolean, replacing the three-valued `LoginResult` enum (`OK`, `FAILED`, `VERIFICATION_REQUIRED`)

**Error handling simplification**

- Removed the `last_error` instance variable and `_handle_error()` helper from `PlayerAuthAPI`; error information now lives inside the returned result object, making each call fully self-contained
- Removed the `LoginResult` enum entirely

**Consumer API improvements**

- All sample scripts and internal callers (`talo_client.gd`, `session_manager.gd`) now check `res.success` / `res.verification_required` and read `res.error` directly, eliminating the previous pattern of comparing to `OK` or indexing into `Talo.player_auth.last_error`