### PR TITLE
Add config setting to enable http requests to use threads in Godot

### DIFF
--- a/addons/talo/talo_client.gd
+++ b/addons/talo/talo_client.gd
@@ -69,6 +69,7 @@ func make_request(
 	http_request.timeout = 15
 	http_request.accept_gzip = true
 	http_request.name = "%s %s" % [_get_method_name(method), url]
+	http_request.use_threads = Talo.settings.requests_use_threads
 
 	http_request.request(full_url, all_headers, method, request_body)
 	var res := _simulate_offline_request() if Talo.settings.offline_mode else await _build_response(http_request)

--- a/addons/talo/talo_settings.gd
+++ b/addons/talo/talo_settings.gd
@@ -96,6 +96,13 @@ var debounce_timer_seconds: float:
 	set(value):
 		_config_file.set_value("", "debounce_timer_seconds", value)
 
+## When making requests via HTTPRequest set use_threads to this value
+var requests_use_threads: bool:
+	get:
+		return _config_file.get_value("", "requests_use_threads", false)
+	set(value):
+		_config_file.set_value("", "requests_use_threads", value)
+
 ## Enable request verification to prevent replay attacks and tampering - this must also be enabled in the dashboard
 var verification_enabled: bool:
 	get:
@@ -131,6 +138,7 @@ func _init() -> void:
 		auto_start_session = auto_start_session
 		cache_player_on_identify = cache_player_on_identify
 		debounce_timer_seconds = debounce_timer_seconds
+		requests_use_threads = requests_use_threads
 		verification_enabled = verification_enabled
 		verification_key_version = verification_key_version
 		verification_key_value = verification_key_value


### PR DESCRIPTION
Default value in config is the default value assumed by Talo now. This just allows the user to opt-in to this feature via .cfg

Tested by exporting "Windows Desktop" using godot's premade 4.7 binary, no script errors. 
Tested in personal project with config setting set (`requests_use_threads=true`), script processing frame time for game went from 800ms to 16ms on the call to flush(). Saw events in Talo dashboard for my dev user using this new setting also. 