### PR TITLE
Don't run summary for forks, do run build-check and unit-tests

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -2,6 +2,7 @@ name: Build check
 
 on:
   push:
+    branches: [develop]
   pull_request:
 
 jobs:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,6 +1,8 @@
 name: Build check
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   build-check:

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   summarise:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,8 @@
 name: Unit tests
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,7 @@ name: Unit tests
 
 on:
   push:
+    branches: [develop]
   pull_request:
 
 jobs:


### PR DESCRIPTION
**CI trigger scoping**
- Build checks and unit tests now run only on pushes to `develop` (not every branch) and on all pull requests, reducing wasted CI runs on feature branches

**Fork safety**
- The PR summary workflow is skipped for forked repositories, preventing potential secret-exposure issues from untrusted fork contexts