### PR TITLE
Remove prop rejection signals, keep them inline with update results

### DIFF
--- a/addons/talo/apis/channels_api.gd
+++ b/addons/talo/apis/channels_api.gd
@@ -17,8 +17,6 @@ signal channel_ownership_transferred(channel: TaloChannel, new_owner_player_alia
 signal channel_deleted(channel: TaloChannel)
 ## Emitted when a channel is updated.
 signal channel_updated(channel: TaloChannel, changed_properties: Array[String])
-## Emitted when one or more props are rejected during a channel create or update.
-signal channel_props_rejected(rejected_props: Array[TaloRejectedProp])
 ## Emitted when channel storage props are updated or deleted.
 signal channel_storage_props_updated(channel: TaloChannel, upserted_props: Array[TaloChannelStorageProp], deleted_props: Array[TaloChannelStorageProp])
 ## Emitted when one or more storage props were not successfully set.
@@ -118,9 +116,9 @@ func get_subscribed_channels(options: GetSubscribedChannelsOptions = GetSubscrib
 			return []
 
 ## Create a new channel. The player who creates this channel will automatically become the owner. If auto cleanup is enabled, the channel will be deleted when the owner or the last member leaves. Private channels can only be joined by players who have been invited to the channel. Channels with temporary membership will remove players at the end of their session.
-func create(options: CreateChannelOptions = CreateChannelOptions.new()) -> TaloChannel:
+func create(options: CreateChannelOptions = CreateChannelOptions.new()) -> ChannelUpsertResult:
 	if Talo.identity_check() != OK:
-		return
+		return ChannelUpsertResult.new(false, null)
 
 	var props_to_send := options.props \
 		.keys() \
@@ -136,15 +134,12 @@ func create(options: CreateChannelOptions = CreateChannelOptions.new()) -> TaloC
 
 	match res.status:
 		200:
-			return TaloChannel.new(res.body.channel)
+			return ChannelUpsertResult.new(true, TaloChannel.new(res.body.channel))
 		400:
 			var rejected_props := TaloRejectedProp.from_response(res.body)
-			if rejected_props.size() > 0:
-				channel_props_rejected.emit(rejected_props)
-
-			return null
+			return ChannelUpsertResult.new(false, null, rejected_props)
 		_:
-			return null
+			return ChannelUpsertResult.new(false, null)
 
 ## Join an existing channel.
 func join(channel_id: int) -> TaloChannel:
@@ -167,9 +162,9 @@ func leave(channel_id: int) -> void:
 	await client.make_request(HTTPClient.METHOD_POST, "/%s/leave" % channel_id)
 
 ## Update a channel. This will only work if the current player is the owner of the channel.
-func update(channel_id: int, options: UpdateChannelOptions = UpdateChannelOptions.new()) -> TaloChannel:
+func update(channel_id: int, options: UpdateChannelOptions = UpdateChannelOptions.new()) -> ChannelUpsertResult:
 	if Talo.identity_check() != OK:
-		return
+		return ChannelUpsertResult.new(false, null)
 
 	var data := {}
 	if not options.name.is_empty():
@@ -189,18 +184,15 @@ func update(channel_id: int, options: UpdateChannelOptions = UpdateChannelOption
 
 	match res.status:
 		200:
-			return TaloChannel.new(res.body.channel)
+			return ChannelUpsertResult.new(true, TaloChannel.new(res.body.channel))
 		400:
 			var rejected_props := TaloRejectedProp.from_response(res.body)
-			if rejected_props.size() > 0:
-				channel_props_rejected.emit(rejected_props)
-
-			return null
+			return ChannelUpsertResult.new(false, null, rejected_props)
 		403:
 			push_error("Player does not have permissions to update channel %s." % channel_id)
-			return null
+			return ChannelUpsertResult.new(false, null)
 		_:
-			return null
+			return ChannelUpsertResult.new(false, null)
 
 ## Delete a channel. This will only work if the current player is the owner of the channel.
 func delete(channel_id: int) -> void:
@@ -433,3 +425,13 @@ class MembersPage:
 		self.count = count
 		self.items_per_page = items_per_page
 		self.is_last_page = is_last_page
+
+class ChannelUpsertResult:
+	var success: bool
+	var channel: TaloChannel
+	var rejected_props: Array[TaloRejectedProp]
+
+	func _init(success: bool, channel: TaloChannel, rejected_props: Array[TaloRejectedProp] = []) -> void:
+		self.success = success
+		self.channel = channel
+		self.rejected_props = rejected_props

--- a/addons/talo/apis/feedback_api.gd
+++ b/addons/talo/apis/feedback_api.gd
@@ -5,9 +5,6 @@ class_name FeedbackAPI extends TaloAPI
 ##
 ## @tutorial: https://docs.trytalo.com/docs/godot/feedback
 
-## Emitted when one or more props are rejected during feedback submission.
-signal props_rejected(rejected_props: Array[TaloRejectedProp])
-
 ## Get a list of feedback categories that are available for players to submit feedback.
 func get_categories() -> Array[TaloFeedbackCategory]:
 	var res := await client.make_request(HTTPClient.METHOD_GET, "/categories")
@@ -21,9 +18,9 @@ func get_categories() -> Array[TaloFeedbackCategory]:
 			return []
 
 ## Submit feedback for a specific category. Optionally add props for extra context.
-func send(category_internal_name: String, comment: String, props: Dictionary[String, String] = {}) -> void:
+func send(category_internal_name: String, comment: String, props: Dictionary[String, String] = {}) -> FeedbackSendResult:
 	if Talo.identity_check() != OK:
-		return
+		return FeedbackSendResult.new(false)
 
 	var props_to_send := props \
 		.keys() \
@@ -35,7 +32,17 @@ func send(category_internal_name: String, comment: String, props: Dictionary[Str
 	})
 
 	match res.status:
+		200:
+			return FeedbackSendResult.new(true)
 		400:
-			var rejected_props := TaloRejectedProp.from_response(res.body)
-			if rejected_props.size() > 0:
-				props_rejected.emit(rejected_props)
+			return FeedbackSendResult.new(false, TaloRejectedProp.from_response(res.body))
+		_:
+			return FeedbackSendResult.new(false)
+
+class FeedbackSendResult:
+	var success: bool
+	var rejected_props: Array[TaloRejectedProp]
+
+	func _init(success: bool, rejected_props: Array[TaloRejectedProp] = []) -> void:
+		self.success = success
+		self.rejected_props = rejected_props

--- a/addons/talo/apis/leaderboards_api.gd
+++ b/addons/talo/apis/leaderboards_api.gd
@@ -5,9 +5,6 @@ class_name LeaderboardsAPI extends TaloAPI
 ##
 ## @tutorial: https://docs.trytalo.com/docs/godot/leaderboards
 
-## Emitted when one or more props are rejected during an entry add.
-signal props_rejected(rejected_props: Array[TaloRejectedProp])
-
 var _entries_manager := TaloLeaderboardEntriesManager.new()
 
 ## Get a list of all the entries that have been previously fetched or created for a leaderboard. The options include "alias_id", "player_id" and "alias_service" for additional filtering.
@@ -76,7 +73,7 @@ func get_entries(internal_name: String, options := GetEntriesOptions.new()) -> E
 ## Add an entry to a leaderboard. The props (key-value pairs) parameter is used to store additional data with the entry.
 func add_entry(internal_name: String, score: float, props: Dictionary[String, Variant] = {}) -> AddEntryResult:
 	if Talo.identity_check() != OK:
-		return null
+		return AddEntryResult.new(null, false)
 
 	var res := await client.make_request(HTTPClient.METHOD_POST, "/%s/entries" % internal_name, {
 		score = score,
@@ -91,12 +88,9 @@ func add_entry(internal_name: String, score: float, props: Dictionary[String, Va
 			return AddEntryResult.new(entry, res.body.updated)
 		400:
 			var rejected_props := TaloRejectedProp.from_response(res.body)
-			if rejected_props.size() > 0:
-				props_rejected.emit(rejected_props)
-
-			return null
+			return AddEntryResult.new(null, false, rejected_props)
 		_:
-			return null
+			return AddEntryResult.new(null, false)
 
 class EntriesPage:
 	var entries: Array[TaloLeaderboardEntry]
@@ -113,10 +107,12 @@ class EntriesPage:
 class AddEntryResult:
 	var entry: TaloLeaderboardEntry
 	var updated: bool
+	var rejected_props: Array[TaloRejectedProp]
 
-	func _init(entry: TaloLeaderboardEntry, updated: bool) -> void:
+	func _init(entry: TaloLeaderboardEntry, updated: bool, rejected_props: Array[TaloRejectedProp] = []) -> void:
 		self.entry = entry
 		self.updated = updated
+		self.rejected_props = rejected_props
 
 class GetEntriesOptions:
 	var page: int = 0

--- a/addons/talo/apis/players_api.gd
+++ b/addons/talo/apis/players_api.gd
@@ -17,9 +17,6 @@ signal identification_failed(error: TaloIdentifyError)
 ## Emitted after calling clear_identity().
 signal identity_cleared()
 
-## Emitted when one or more props are rejected during a player update.
-signal props_rejected(rejected_props: Array[TaloRejectedProp])
-
 ## Emitted when a debounced player update settles.
 signal player_updated(success: bool)
 
@@ -108,9 +105,6 @@ func _run_debounced_update() -> Variant:
 			Talo.current_alias.write_offline_alias()
 
 			var rejected_props := TaloRejectedProp.from_response(res.body)
-			if rejected_props.size() > 0:
-				props_rejected.emit(rejected_props)
-
 			return rejected_props
 		_:
 			return null

--- a/addons/talo/apis/saves_api.gd
+++ b/addons/talo/apis/saves_api.gd
@@ -195,7 +195,7 @@ func delete_save(save: TaloGameSave, unload_if_current_save: bool = false) -> vo
 func get_format_version() -> String:
 	return _saves_manager.get_format_version()
 
-class SaveUpdateResult extends RefCounted:
+class SaveUpdateResult:
 	var success: bool
 	var save: TaloGameSave
 

--- a/addons/talo/samples/channel_storage/scripts/channel_storage_demo.gd
+++ b/addons/talo/samples/channel_storage/scripts/channel_storage_demo.gd
@@ -29,7 +29,9 @@ func _ready() -> void:
 		create_options.props = {
 			"channel-storage-demo": "true"
 		}
-		demo_channel = await Talo.channels.create(create_options)
+		var result := await Talo.channels.create(create_options)
+		if result.success:
+			demo_channel = result.channel
 
 	await Talo.channels.join(demo_channel.id)
 

--- a/addons/talo/samples/chat/scripts/chat.gd
+++ b/addons/talo/samples/chat/scripts/chat.gd
@@ -46,10 +46,10 @@ func _on_add_channel_button_pressed() -> void:
 	options.name = %ChannelName.text
 	options.auto_cleanup = true
 
-	var channel := await Talo.channels.create(options)
-	if channel:
-		_subscriptions.append(channel)
-		_add_channel_label(channel.id, channel.name)
+	var result := await Talo.channels.create(options)
+	if result.success:
+		_subscriptions.append(result.channel)
+		_add_channel_label(result.channel.id, result.channel.name)
 		%ChannelName.text = ""
 
 func _add_chat_message(message: String) -> void:

--- a/addons/talo/samples/leaderboards/scripts/leaderboard.gd
+++ b/addons/talo/samples/leaderboards/scripts/leaderboard.gd
@@ -75,7 +75,7 @@ func _on_submit_pressed() -> void:
 	var team := "Blue" if RandomNumberGenerator.new().randi_range(0, 1) == 0 else "Red"
 
 	var res := await Talo.leaderboards.add_entry(leaderboard_internal_name, score, {team = team})
-	assert(is_instance_valid(res))
+	assert(res.entry != null)
 	info_label.text = "You scored %s points for the %s team!%s" % [score, team, " Your highscore was updated!" if res.updated else ""]
 
 	_build_entries()

--- a/addons/talo/samples/playground/scripts/add_entry_button.gd
+++ b/addons/talo/samples/playground/scripts/add_entry_button.gd
@@ -14,5 +14,5 @@ func _on_pressed() -> void:
 	var score := RandomNumberGenerator.new().randi_range(1, 50)
 	var res := await Talo.leaderboards.add_entry(leaderboard_name, score)
 
-	if is_instance_valid(res):
+	if res.entry:
 		%ResponseLabel.text = "Added score: %s, new high score: %s" % [score, res.updated]

--- a/addons/talo/samples/playground/scripts/delete_prop_button.gd
+++ b/addons/talo/samples/playground/scripts/delete_prop_button.gd
@@ -11,4 +11,5 @@ func _on_pressed() -> void:
 		%ResponseLabel.text = "prop_name not set on DeletePropButton"
 		return
 
-	Talo.current_player.delete_prop(prop_name)
+	var result: PlayersAPI.PlayerUpdateResult = await Talo.current_player.delete_prop(prop_name)
+	%ResponseLabel.text = "%s deleted successfully" % prop_name if result.success else "Failed to delete %s" % prop_name


### PR DESCRIPTION
**Structured result types replacing signal-based error handling**

- Channel create/update operations now return `ChannelUpsertResult` instead of nullable `TaloChannel`, carrying success status, channel, and rejected props
- Feedback submission returns `FeedbackSendResult` instead of void, explicitly indicating success or failure
- Leaderboard entry additions return `AddEntryResult` with a new `rejected_props` field instead of null on failure
- Player updates return `PlayerUpdateResult` with explicit success/rejected_props fields

**Removal of rejected-props signals**

- Removed `channel_props_rejected` signal from ChannelsAPI
- Removed `props_rejected` signal from FeedbackAPI, LeaderboardsAPI, and PlayersAPI
- Rejected props are now returned directly in result objects rather than emitted via signals, making error handling synchronous and explicit

**Sample code updates for new API patterns**

- Channel storage and chat samples now check `result.success` before accessing `result.channel`
- Leaderboard samples check `res.entry != null` instead of `is_instance_valid(res)`
- Prop deletion sample now awaits the result and displays success/failure feedback