### PR TITLE
Make default debounce time 0.5 seconds

### DIFF
--- a/addons/talo/talo_settings.gd
+++ b/addons/talo/talo_settings.gd
@@ -92,7 +92,7 @@ var cache_player_on_identify: bool:
 ## Number of seconds to wait before sending debounced requests (e.g. player updates, save updates and health checks)
 var debounce_timer_seconds: float:
 	get:
-		return _config_file.get_value("", "debounce_timer_seconds", 1.0)
+		return _config_file.get_value("", "debounce_timer_seconds", 0.5)
 	set(value):
 		_config_file.set_value("", "debounce_timer_seconds", value)
 

--- a/test/settings/talo_settings_test.gd
+++ b/test/settings/talo_settings_test.gd
@@ -234,8 +234,8 @@ func test_cache_player_on_identify_writing() -> void:
 
 # debounce_timer_seconds
 
-func test_debounce_timer_seconds_defaults_to_1() -> void:
-	assert_float(Talo.settings.debounce_timer_seconds).is_equal(1.0)
+func test_debounce_timer_seconds_defaults_to_0point5() -> void:
+	assert_float(Talo.settings.debounce_timer_seconds).is_equal(0.5)
 
 func test_debounce_timer_seconds_reading() -> void:
 	var file := ConfigFile.new()
@@ -249,7 +249,7 @@ func test_debounce_timer_seconds_writing() -> void:
 	Talo.settings.save_config()
 	var file := ConfigFile.new()
 	file.load(TaloSettings.SETTINGS_PATH)
-	assert_float(file.get_value("", "debounce_timer_seconds", 1.0)).is_equal(2.5)
+	assert_float(file.get_value("", "debounce_timer_seconds", 0.5)).is_equal(2.5)
 
 # verification_enabled
 


### PR DESCRIPTION
**Debounce timer default adjustment**
- Default debounce timer reduced from 1.0 seconds to 0.5 seconds, making debounced requests (player updates, save updates, health checks) fire sooner by default.